### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# For details about the settings in this file see: https://git-scm.com/docs/gitattributes
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto


### PR DESCRIPTION
This adds a `.gitattributes` file to ensure that line endings in text files are always stored in Unix style (= LF only) in the git repository itself but converted to Windows/Unix line endings when files are checked depending on the operating system.