### PR TITLE
Rename qcb build targets

### DIFF
--- a/qcrbox/qcrbox/cli/subcommands/build.py
+++ b/qcrbox/qcrbox/cli/subcommands/build.py
@@ -33,7 +33,7 @@ def build_components(no_deps: bool, dry_run: bool, components: list[str]):
 
 
 def make_task_for_component(component_name: str, docker_project: DockerProject, with_deps: bool, dry_run: bool):
-    if component_name == "qcrbox":
+    if component_name == "pyqcrbox":
         task = task_build_qcrbox_python_package(dry_run)
     else:
         task = task_build_docker_image(component_name, docker_project, with_deps=with_deps, dry_run=dry_run)
@@ -146,7 +146,7 @@ def populate_build_tasks(
 def update_build_tasks(
     existing_tasks: dict, component: str, docker_project: DockerProject, with_deps: bool, dry_run: bool
 ):
-    if component == "qcrbox":
+    if component == "pyqcrbox":
         new_tasks = [
             task_build_qcrbox_python_package(dry_run),
         ]
@@ -161,7 +161,7 @@ def update_build_tasks(
             for dep in docker_project.get_direct_dependencies(component, include_build_deps=True):
                 update_build_tasks(existing_tasks, dep, docker_project, with_deps=with_deps, dry_run=dry_run)
             if component == "base-ancestor":
-                update_build_tasks(existing_tasks, "qcrbox", docker_project, with_deps=with_deps, dry_run=dry_run)
+                update_build_tasks(existing_tasks, "pyqcrbox", docker_project, with_deps=with_deps, dry_run=dry_run)
                 update_build_tasks(existing_tasks, "qcrboxtools", docker_project, with_deps=with_deps, dry_run=dry_run)
 
     for task in new_tasks:

--- a/qcrbox/qcrbox/cli/subcommands/build.py
+++ b/qcrbox/qcrbox/cli/subcommands/build.py
@@ -32,14 +32,6 @@ def build_components(no_deps: bool, dry_run: bool, components: list[str]):
     run_tasks(tasks)
 
 
-def make_task_for_component(component_name: str, docker_project: DockerProject, with_deps: bool, dry_run: bool):
-    if component_name == "pyqcrbox":
-        task = task_build_qcrbox_python_package(dry_run)
-    else:
-        task = task_build_docker_image(component_name, docker_project, with_deps=with_deps, dry_run=dry_run)
-    return task
-
-
 def make_action_to_copy_file(src, dest):
     def action_copy_file():
         # logger.debug(f"Copying file: {src} -> {dest}")

--- a/qcrbox/qcrbox/cli/subcommands/build.py
+++ b/qcrbox/qcrbox/cli/subcommands/build.py
@@ -150,7 +150,7 @@ def update_build_tasks(
         new_tasks = [
             task_build_qcrbox_python_package(dry_run),
         ]
-    elif component == "qcrboxtools":
+    elif component == "pyqcrboxtools":
         new_tasks = [
             task_clone_qcrboxtools_repo(dry_run),
             task_build_qcrboxtools_python_package(dry_run),
@@ -162,7 +162,9 @@ def update_build_tasks(
                 update_build_tasks(existing_tasks, dep, docker_project, with_deps=with_deps, dry_run=dry_run)
             if component == "base-ancestor":
                 update_build_tasks(existing_tasks, "pyqcrbox", docker_project, with_deps=with_deps, dry_run=dry_run)
-                update_build_tasks(existing_tasks, "qcrboxtools", docker_project, with_deps=with_deps, dry_run=dry_run)
+                update_build_tasks(
+                    existing_tasks, "pyqcrboxtools", docker_project, with_deps=with_deps, dry_run=dry_run
+                )
 
     for task in new_tasks:
         existing_tasks[task.name] = task


### PR DESCRIPTION
This PR renames the build targets for the Python packages:

- `qcb build qcrbox` -> `qcb build pyqcrbox`
- `qcb build qcrboxtools` -> `qcb build pyqcrboxtools`

Resolves #117 