### PR TITLE
Fix command registration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,8 @@ However, there will be an initial period of stabilisation where this is not adhe
 
 - Ensured that the `qcb` tool works cross-platform, including on Windows. ([#76](https://github.com/QCrBox/QCrBox/issues/76))
 - Line endings of text files checked out in the git working tree are always normalised to `LF` to avoid runtime errors on Windows. ([#132](https://github.com/QCrBox/QCrBox/issues/132))
+- Command registration and internal error handling by the server. ([#172](https://github.com/QCrBox/QCrBox/issues/172))
+
 
 ### Internal changes & improvements
 

--- a/qcrbox/pyproject.toml
+++ b/qcrbox/pyproject.toml
@@ -69,6 +69,7 @@ all = [
 [project.scripts]
 qcb = "qcrbox.cli:entry_point"
 qcrbox-run-registry-server = "qcrbox.registry.server:main"
+qcrbox-run-registry-dummy-client = "qcrbox.registry.client.client:main"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/qcrbox/pyproject.toml
+++ b/qcrbox/pyproject.toml
@@ -69,7 +69,7 @@ all = [
 [project.scripts]
 qcb = "qcrbox.cli:entry_point"
 qcrbox-run-registry-server = "qcrbox.registry.server:main"
-qcrbox-run-registry-dummy-client = "qcrbox.registry.client.client:main"
+qcrbox-run-dummy-client = "qcrbox.registry.client.client:main"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/qcrbox/qcrbox/registry/client/client.py
+++ b/qcrbox/qcrbox/registry/client/client.py
@@ -14,6 +14,7 @@ from qcrbox.common import get_qcrbox_registry_api_connection_url, get_rabbitmq_c
 
 from ...logging import logger
 from ..helpers import schedule_asyncio_task
+from .external_command import ExternalCommand
 from .helpers import create_new_container_qcrbox_id, create_new_private_routing_key
 from .message_processing import process_message_sync_or_async
 from .registered_application_client_side import RegisteredApplicationClientSide
@@ -206,3 +207,17 @@ class QCrBoxRegistryClient:
 
         self.event_loop.run_until_complete(main_task)
         self.event_loop.close()
+
+
+def main():
+    client = QCrBoxRegistryClient()
+    application = client.register_application("Dummy Application", version="x.y.z")
+    application.register_external_command(
+        "print_and_sleep",
+        ExternalCommand("python", "-c", "import time; print('Hello world!'); time.sleep(1); print('KTHXBYE')"),
+    )
+    client.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/qcrbox/qcrbox/registry/client/registered_application_client_side.py
+++ b/qcrbox/qcrbox/registry/client/registered_application_client_side.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import asyncio
+import sys
 from typing import Callable, Optional
 
 from loguru import logger
@@ -85,7 +86,9 @@ class RegisteredApplicationClientSide:
             self._command_callbacks[response.payload["command_id"]] = on_command_invoked
             logger.info(f"Successfully registered command {cmd_name!r}")
         elif response.status == "error":
-            raise Exception(response.msg)
+            logger.error("Received error response from server.")
+            logger.error(f"Error message: {response.msg}")
+            sys.exit(1)
         else:
             raise RuntimeError(f"Unexpected response status: {response.status}")
 

--- a/qcrbox/qcrbox/registry/server/server.py
+++ b/qcrbox/qcrbox/registry/server/server.py
@@ -66,8 +66,9 @@ async def handle_incoming_messages(msg_dict) -> msg_specs.QCrBoxGenericResponse:
                 # this action does not match; try the next one instead
                 continue
             else:
-                logger.error(f"Invalid message structure for action {msg_dict['action']!r}. Errors: {exc.errors()}")
-                raise
+                error_msg = f"Invalid message structure for action {msg_dict['action']!r}. Errors: {exc.errors()}"
+                logger.error(error_msg)
+                return msg_specs.QCrBoxGenericResponse(response_to="incoming_message", status="error", msg=error_msg)
     else:
         error_msg = f"Invalid action: {msg_dict['action']!r}"
         logger.error(error_msg)

--- a/qcrbox/qcrbox/registry/server/server.py
+++ b/qcrbox/qcrbox/registry/server/server.py
@@ -29,7 +29,7 @@ async def report_successful_startup(_: FastAPI):
 
 def action_does_not_match(exc: pydantic.ValidationError):
     def is_action_mismatch_error(err_dict):
-        return err_dict["loc"] == ("action",) and err_dict["type"] == "value_error.const"
+        return err_dict["loc"] == ("action",) and err_dict["type"] in ("literal_error", "value_error.const")
 
     assert isinstance(exc, pydantic.ValidationError)
     return [] != [err_dict for err_dict in exc.errors() if is_action_mismatch_error(err_dict)]


### PR DESCRIPTION
Fixes #172

The fix itself involves checking the pydantic error type for `"literal_error"`. In addition, the server now responds with a proper error message to the client instead of raising an internal exception.

I also added a little bit of debug scaffolding so that a dummy client can be run locally via `qcrbox-run-dummy-client`.