### PR TITLE
update docs with instruction for Win11 error

### DIFF
--- a/docs/how_to_guides/set_up_a_dev_environment.md
+++ b/docs/how_to_guides/set_up_a_dev_environment.md
@@ -137,3 +137,19 @@ $ qcb list components
 ```console exec="1" source="console"
 $ qcb list components --all
 ```
+
+## Build a container to test the installation
+
+Try building a component by typing:
+```console exec="1" source="console"
+$ qcb build qcrboxtools
+```
+> **Note:** There were issues with running hatchling under Windows 11, especially when using a python version from the Windows Store. If ``qcb build`` fails during ``Building Python package: qcrbox`` with a code 106 error (or silent without ``-v``), try the following remedy:
+>
+> 1. Uninstall the Windows Store python version using the app uninstall of windows
+>
+> 2. Get a new installer from [python.org](https://www.python.org/)
+> 
+> 3. Install. Activate support for long paths and add python to path
+>
+> 4. Delete the venv folder and create a new one with the new python version


### PR DESCRIPTION
Update dev build docs to include a test run building the QCrBoxTools container and instructions on how to fix the Win11 error