### PR TITLE
Fix API paths in qcb subcommands and qcrbox wrapper

### DIFF
--- a/pyqcrbox/pyqcrbox/cli/subcommands/invoke.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/invoke.py
@@ -37,7 +37,7 @@ def invoke_command(command_name: str, command_args: list[str], application_slug:
         arguments=arguments,
     )
     response = requests.post(
-        settings.registry.server.api_url + "commands/invoke",
+        settings.registry.server.api_url + "/commands/invoke",
         cmd.model_dump_json().encode(),
     )
     if not response.ok:

--- a/pyqcrbox/pyqcrbox/cli/subcommands/list.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/list.py
@@ -100,7 +100,7 @@ def list_applications(slug: Optional[str], version: Optional[str]):
     """
     List registered applications.
     """
-    r = run_request_against_registry_api("/api/applications", params={"slug": slug, "version": version})
+    r = run_request_against_registry_api("/applications", params={"slug": slug, "version": version})
 
     cols_to_print = (
         "id",
@@ -149,7 +149,7 @@ def list_commands(
     List registered commands.
     """
     r = run_request_against_registry_api(
-        "/api/commands",
+        "/commands",
         params={"name": name, "application_slug": application_slug, "application_version": application_version},
     )
     assert r.status_code == 200, "Error retrieving commands from server"

--- a/pyqcrbox/pyqcrbox/cli/subcommands/list.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/list.py
@@ -100,7 +100,7 @@ def list_applications(slug: Optional[str], version: Optional[str]):
     """
     List registered applications.
     """
-    r = run_request_against_registry_api("/applications", params={"slug": slug, "version": version})
+    r = run_request_against_registry_api("/api/applications", params={"slug": slug, "version": version})
 
     cols_to_print = (
         "id",
@@ -149,12 +149,12 @@ def list_commands(
     List registered commands.
     """
     r = run_request_against_registry_api(
-        "/commands",
+        "/api/commands",
         params={"name": name, "application_slug": application_slug, "application_version": application_version},
     )
     assert r.status_code == 200, "Error retrieving commands from server"
     cols_to_print = (
-        #"id",
+        # "id",
         "application",
         "version",
         "cmd_name",

--- a/pyqcrbox/pyqcrbox/cli/subcommands/status.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/status.py
@@ -20,7 +20,7 @@ def retrieve_status(calculation_id: str, use_json_output: bool = False):
         click.echo(f"Invalid calculation id: {calculation_id!r}")
         sys.exit(1)
 
-    response = requests.get(settings.registry.server.api_url + f"calculations/{calculation_id}")
+    response = requests.get(settings.registry.server.api_url + f"/calculations/{calculation_id}")
     if not response.ok:
         if response.status_code == 404:
             click.echo(f"Calculation not found: {calculation_id!r}")
@@ -36,6 +36,7 @@ def retrieve_status(calculation_id: str, use_json_output: bool = False):
         click.echo(data)
     else:
         from pyqcrbox import logger
+
         logger.debug(data)
         click.echo(f"Calculation id: {data['calculation_id']}")
         click.echo(f"Status: {data['status']}")

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -18,7 +18,7 @@ from . import api_helpers
 
 @get("/", media_type=MediaType.JSON, include_in_schema=False)
 async def api_root_handler() -> dict[str, Any]:
-    return {"message": "Hello world!"}
+    return {"message": "Hello from QCrBox!"}
 
 
 @get(path="/healthz", media_type=MediaType.JSON, skip_logging=False)

--- a/pyqcrbox/pyqcrbox/settings.py
+++ b/pyqcrbox/pyqcrbox/settings.py
@@ -97,7 +97,7 @@ class ServerAPISettings(QCrBoxSettingsBaseModel):
     @computed_field  # type: ignore
     @property
     def api_url(self) -> str:
-        return f"http://{self.host}:{self.port}/"
+        return f"http://{self.host}:{self.port}/api"
 
 
 class ClientAPISettings(QCrBoxSettingsBaseModel):

--- a/pyqcrbox/tests/end_to_end_tests/test_qcb_list.sh
+++ b/pyqcrbox/tests/end_to_end_tests/test_qcb_list.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#readonly PROGNAME=$(basename $0)
+#readonly CUR_WORK_DIR=$(pwd)
+#readonly ARGS="$*"
+
+
+verify_output_of_qcb_list_applications() {
+    if qcb list applications |
+       grep -q "dummy_cli.*Dummy CLI.*0.1.0";
+    then
+        echo "Success: 'qcb list applications' contained expected info about Dummy CLI"
+    else
+        exit 1
+    fi
+}
+
+
+verify_output_of_qcb_list_commands() {
+    if qcb list commands |
+       grep -q "greet_and_sleep";
+    then
+        echo "Success: 'qcb list commands' contained expected output 'greet_and_sleep'"
+    else
+        exit 1
+    fi
+}
+
+
+
+main() {
+    verify_output_of_qcb_list_applications
+    verify_output_of_qcb_list_commands
+}
+main

--- a/qcrbox_wrapper/qcrbox_wrapper/qcrbox_wrapper.py
+++ b/qcrbox_wrapper/qcrbox_wrapper/qcrbox_wrapper.py
@@ -174,8 +174,8 @@ class QCrBoxWrapper:
         server_port: Optional[int] = None,
         gui_infos: Optional[dict[str, dict[str, Union[int, str]]]] = None,
     ) -> "QCrBoxWrapper":
-        server_url = f"http://{server_addr}" + (f":{server_port}" if server_port is not None else "")
-        web_client = httpx.Client(base_url=server_url)
+        server_api_url = f"http://{server_addr}" + (f":{server_port}" if server_port is not None else "") + "/api"
+        web_client = httpx.Client(base_url=server_api_url)
 
         # with urllib.request.urlopen(f"{server_url}") as r:
         #     response = r.read().decode("UTF-8")
@@ -201,9 +201,7 @@ class QCrBoxWrapper:
         """
         response = get_time_cached_app_answer(self.web_client, get_ttl_hash())
         return [
-            QCrBoxApplication(
-                application_spec=sql_models.ApplicationSpecWithCommands(**app_spec), wrapper_parent=self
-            )
+            QCrBoxApplication(application_spec=sql_models.ApplicationSpecWithCommands(**app_spec), wrapper_parent=self)
             for app_spec in response
         ]
 


### PR DESCRIPTION
The API endpoints now live under the `/api` prefix. This PR updates the paths in the various `qcb` subcommands as well as the qcrbox wrapper to ensure the requests hit the correct endpoints.