### PR TITLE
Fix build under WSL

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 ### Issues Fixed
 
 - Browser windows now open correctly under WSL. ([#274](https://github.com/QCrBox/QCrBox/issues/274)
+- Fixed a build issue under WSL. ([#335](https://github.com/QCrBox/QCrBox/issues/335))
 
 ### Development
 

--- a/pyqcrbox/pyproject.toml
+++ b/pyqcrbox/pyproject.toml
@@ -43,7 +43,6 @@ dev = [
     "reuse",
     "ruff",
     "setuptools_scm",
-    "uv",
     #
     # linting
     "import-linter",

--- a/pyqcrbox/pyqcrbox/cli/subcommands/build.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/build.py
@@ -63,7 +63,7 @@ def make_action_to_copy_file(src, dest):
 
 def make_action_to_build_wheel(package_root, output_dir):
     def _action_build_wheel_for_python_package():
-        cmd = [shutil.which("hatch"), "build", "-t", "wheel", str(output_dir)]
+        cmd = f"hatch build -t wheel {output_dir}"
         proc = subprocess.run(cmd, cwd=package_root, shell=True, check=False, capture_output=True)
 
         try:

--- a/pyqcrbox/pyqcrbox/cli/subcommands/build.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/build.py
@@ -75,26 +75,6 @@ def make_action_to_build_wheel(package_root, output_dir):
     return _action_build_wheel_for_python_package
 
 
-def make_action_to_build_pyqcrbox_wheel(base_ancestor_pyqcrbox_dist_dir):
-    def action_build_pyqcrbox_wheel():
-        repo_root = get_repo_root()
-        pyqcrbox_package_root = repo_root.joinpath("pyqcrbox")
-
-        try:
-            cmd = [shutil.which("hatch"), "build", "-t", "wheel", str(base_ancestor_pyqcrbox_dist_dir)]
-            proc = subprocess.run(cmd, cwd=pyqcrbox_package_root, shell=True, check=False, capture_output=True)
-        except Exception as exc:
-            raise QCrBoxSubprocessError(f"Error when trying to run docker compose command: {exc}")
-
-        try:
-            proc.check_returncode()
-        except subprocess.CalledProcessError as exc:
-            error_msg = prettyprint_called_process_error(exc)
-            raise QCrBoxSubprocessError(error_msg)
-
-    return action_build_pyqcrbox_wheel
-
-
 @make_task
 def task_clone_qcrboxtools_repo(dry_run: bool):
     qcrboxtools_repo_url = "https://github.com/QCrBox/QCrBoxTools.git"
@@ -147,7 +127,7 @@ def task_build_qcrboxtools_python_package(dry_run: bool):
             qcrboxtools_package_root, base_ancestor_pyqcrbox_dist_dir
         )
         # actions_copy_requirements_files = [
-        #     make_action_to_copy_file(filename, base_ancestor_qcrbox_dist_dir) for filename in requirements_files
+        #     make_action_to_copy_file(filename, base_ancestor_pyqcrbox_dist_dir) for filename in requirements_files
         # ]
 
         actions += [action_build_qcrboxtools_wheel]

--- a/pyqcrbox/pyqcrbox/cli/subcommands/build.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/build.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Iterable
 
@@ -11,12 +10,10 @@ from loguru import logger
 from ..helpers import (
     ClickCommandCls,
     DockerProject,
-    QCrBoxSubprocessError,
     add_cli_option_to_enable_or_disable_components,
     add_verbose_option,
     get_repo_root,
     make_task,
-    prettyprint_called_process_error,
     run_tasks,
 )
 from ..helpers.compose_file_config import QCrBoxNoBuildContextError
@@ -62,17 +59,8 @@ def make_action_to_copy_file(src, dest):
 
 
 def make_action_to_build_wheel(package_root, output_dir):
-    def _action_build_wheel_for_python_package():
-        cmd = f"hatch build -t wheel {output_dir}"
-        proc = subprocess.run(cmd, cwd=package_root, shell=True, check=False, capture_output=True)
-
-        try:
-            proc.check_returncode()
-        except subprocess.CalledProcessError as exc:
-            error_msg = prettyprint_called_process_error(exc)
-            raise QCrBoxSubprocessError(error_msg)
-
-    return _action_build_wheel_for_python_package
+    cmd = f"cd {package_root} && hatch build -t wheel {output_dir}"
+    return cmd
 
 
 @make_task

--- a/pyqcrbox/pyqcrbox/cli/subcommands/build.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/build.py
@@ -68,7 +68,7 @@ def make_action_to_build_pyqcrbox_wheel(base_ancestor_pyqcrbox_dist_dir):
 
         try:
             cmd = [shutil.which("hatch"), "build", "-t", "wheel", str(base_ancestor_pyqcrbox_dist_dir)]
-            proc = subprocess.run(cmd, cwd=pyqcrbox_package_root, shell=False, check=False, capture_output=True)
+            proc = subprocess.run(cmd, cwd=pyqcrbox_package_root, shell=True, check=False, capture_output=True)
         except Exception as exc:
             raise QCrBoxSubprocessError(f"Error when trying to run docker compose command: {exc}")
 

--- a/pyqcrbox/pyqcrbox/cli/subcommands/build.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/build.py
@@ -61,6 +61,20 @@ def make_action_to_copy_file(src, dest):
     return action_copy_file
 
 
+def make_action_to_build_wheel(package_root, output_dir):
+    def _action_build_wheel_for_python_package():
+        cmd = [shutil.which("hatch"), "build", "-t", "wheel", str(output_dir)]
+        proc = subprocess.run(cmd, cwd=package_root, shell=True, check=False, capture_output=True)
+
+        try:
+            proc.check_returncode()
+        except subprocess.CalledProcessError as exc:
+            error_msg = prettyprint_called_process_error(exc)
+            raise QCrBoxSubprocessError(error_msg)
+
+    return _action_build_wheel_for_python_package
+
+
 def make_action_to_build_pyqcrbox_wheel(base_ancestor_pyqcrbox_dist_dir):
     def action_build_pyqcrbox_wheel():
         repo_root = get_repo_root()
@@ -100,10 +114,11 @@ def task_build_pyqcrbox_python_package(dry_run: bool):
     action_descr = "Building" if not dry_run else "Would build"
     actions = [lambda: logger.info(f"{action_descr} Python package: pyqcrbox", dry_run=dry_run)]
     if not dry_run:
+        pyqcrbox_package_root = repo_root.joinpath("pyqcrbox")
         base_ancestor_pyqcrbox_dist_dir = repo_root.joinpath("services/base_images/base_ancestor/pyqcrbox_dist/")
         requirements_files = list(repo_root.glob("pyqcrbox/requirements*.txt"))
 
-        action_build_pyqcrbox_wheel = make_action_to_build_pyqcrbox_wheel(base_ancestor_pyqcrbox_dist_dir)
+        action_build_pyqcrbox_wheel = make_action_to_build_wheel(pyqcrbox_package_root, base_ancestor_pyqcrbox_dist_dir)
         actions_copy_requirements_files = [
             make_action_to_copy_file(filename, base_ancestor_pyqcrbox_dist_dir) for filename in requirements_files
         ]
@@ -117,26 +132,6 @@ def task_build_pyqcrbox_python_package(dry_run: bool):
     }
 
 
-def make_action_to_build_qcrboxtools_wheel(base_ancestor_pyqcrbox_dist_dir):
-    def action_build_qcrboxtools_wheel():
-        repo_root = get_repo_root()
-        qcrboxtools_package_root = repo_root.joinpath(".build", "QCrBoxTools")
-
-        try:
-            cmd = [shutil.which("hatch"), "build", "-t", "wheel", str(base_ancestor_pyqcrbox_dist_dir)]
-            proc = subprocess.run(cmd, cwd=qcrboxtools_package_root, shell=True, check=False, capture_output=True)
-        except Exception as exc:
-            raise QCrBoxSubprocessError(f"Error when trying to run docker compose command: {exc}")
-
-        try:
-            proc.check_returncode()
-        except subprocess.CalledProcessError as exc:
-            error_msg = prettyprint_called_process_error(exc)
-            raise QCrBoxSubprocessError(error_msg)
-
-    return action_build_qcrboxtools_wheel
-
-
 @make_task
 def task_build_qcrboxtools_python_package(dry_run: bool):
     repo_root = get_repo_root()
@@ -144,15 +139,18 @@ def task_build_qcrboxtools_python_package(dry_run: bool):
     action_descr = "Building" if not dry_run else "Would build"
     actions = [lambda: logger.info(f"{action_descr} Python package: qcrboxtools", dry_run=dry_run)]
     if not dry_run:
-        base_ancestor_qcrbox_dist_dir = repo_root.joinpath("services/base_images/base_ancestor/pyqcrbox_dist/")
+        qcrboxtools_package_root = repo_root.joinpath(".build", "QCrBoxTools")
+        base_ancestor_pyqcrbox_dist_dir = repo_root.joinpath("services/base_images/base_ancestor/pyqcrbox_dist/")
         # requirements_files = list(qcrboxtools_package_root.glob("requirements*.txt"))
 
-        action_build_qcrbox_wheel = make_action_to_build_qcrboxtools_wheel(base_ancestor_qcrbox_dist_dir)
+        action_build_qcrboxtools_wheel = make_action_to_build_wheel(
+            qcrboxtools_package_root, base_ancestor_pyqcrbox_dist_dir
+        )
         # actions_copy_requirements_files = [
         #     make_action_to_copy_file(filename, base_ancestor_qcrbox_dist_dir) for filename in requirements_files
         # ]
 
-        actions += [action_build_qcrbox_wheel]
+        actions += [action_build_qcrboxtools_wheel]
         # actions += actions_copy_requirements_files
 
     return {

--- a/scripts/devbox/set_env_vars_windows_wsl.sh
+++ b/scripts/devbox/set_env_vars_windows_wsl.sh
@@ -1,3 +1,1 @@
-#export NIX_LD_LIBRARY_PATH=${PWD}/.devbox/nix/profile/default/lib/:${NIX_LD_LIBRARY_PATH:-}
-#export LD_LIBRARY_PATH=${PWD}/.devbox/nix/profile/default/lib/:${LD_LIBRARY_PATH:-}
 export BROWSER=wslview  # Use wslview to open URLs in the default browser

--- a/scripts/devbox/set_env_vars_windows_wsl.sh
+++ b/scripts/devbox/set_env_vars_windows_wsl.sh
@@ -1,3 +1,3 @@
-export NIX_LD_LIBRARY_PATH=${PWD}/.devbox/nix/profile/default/lib/:${NIX_LD_LIBRARY_PATH:-}
-export LD_LIBRARY_PATH=${PWD}/.devbox/nix/profile/default/lib/:${LD_LIBRARY_PATH:-}
+#export NIX_LD_LIBRARY_PATH=${PWD}/.devbox/nix/profile/default/lib/:${NIX_LD_LIBRARY_PATH:-}
+#export LD_LIBRARY_PATH=${PWD}/.devbox/nix/profile/default/lib/:${LD_LIBRARY_PATH:-}
 export BROWSER=wslview  # Use wslview to open URLs in the default browser

--- a/scripts/devbox/set_platform_agnostic_env_vars.sh
+++ b/scripts/devbox/set_platform_agnostic_env_vars.sh
@@ -1,2 +1,6 @@
 # Ensure that 'uv pip install' uses the Python interpreter in the Devbox-managed virtual environnment.
 export UV_PYTHON=$VENV_DIR/bin/python
+
+# Ensure that hatch uses the uv binary and python interpreter installed via Devbox
+export HATCH_ENV_TYPE_VIRTUAL_UV_PATH=$DEVBOX_PACKAGES_DIR/bin/uv
+export HATCH_PYTHON=$DEVBOX_PACKAGES_DIR/bin/python


### PR DESCRIPTION
Fixes #335.

The key change is to set the environment variables `HATCH_PYTHON` (and `HATCH_ENV_TYPE_VIRTUAL_UV_PATH`) to ensure that `hatch` picks up the Python interpreter and uv executable provided by the Devbox shell.

I also included some refactorings which simplify the implementation of the `qcb build` command.