### PR TITLE
Use uv to build python wheels during 'qcb build ...'

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 
 ### Issues Fixed
 
+- Fixed an error when running `qcb build`. ([#335](https://github.com/QCrBox/QCrBox/issues/335))
 
 ### Development
 

--- a/pyqcrbox/pyqcrbox/cli/subcommands/build.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/build.py
@@ -59,7 +59,7 @@ def make_action_to_copy_file(src, dest):
 
 
 def make_action_to_build_wheel(package_root, output_dir):
-    cmd = f"cd {package_root} && hatch build -t wheel {output_dir}"
+    cmd = f"cd {package_root} && uv build --wheel --out-dir {output_dir}"
     return cmd
 
 


### PR DESCRIPTION
Fixes #335 