### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## This PR addresses the following issue(s)
+
+- Fixes #<issue number>
+
+
+## Summary of the changes
+
+
+
+## How was it tested?
+
+
+## Additional considerations / follow-up work needed
+
+
+## Checklist
+
+Please check any boxes that apply to the changes in this PR
+(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).
+
+- [ ] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
+- [ ] I added a changelog entry in `docs/CHANGELOG.md`
+- [ ] I added automated tests for my changes
+- [ ] I updated any relevant documentation
+- [ ] I created separate GitHub issues for any follow-up work needed
+
+- ~~- [ ] Example of a crossed-out item that does not apply to this PR~~

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 
 ### Enhancements
 
+- Added template for pull requests. ([#356](https://github.com/QCrBox/QCrBox/issues/356))
 
 ### Issues Fixed
 


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #356 


## Summary of the changes

Added the file `.github/pull_request_template.md` which GitHub will automatically use upon any new pull requests.


## How was it tested?

No testing was done as the template will only be applied to future pull requests.


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [X] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [X] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~
