### PR TITLE
Return filename, metadata and object id to frontend

### DIFF
--- a/process-compose.yml
+++ b/process-compose.yml
@@ -30,6 +30,17 @@ processes:
     availability:
       restart: "always"
 
+  qcrbox-dev-server:
+    command: "watchmedo auto-restart --pattern=*.py --recursive -- pyqcrbox-run-registry-server"
+    environment:
+      - 'QCRBOX__REGISTRY_SERVER__HOST={{ or "${QCRBOX__REGISTRY_SERVER__HOST}" .QCRBOX__REGISTRY_SERVER__HOST }}'
+      - 'QCRBOX__REGISTRY_SERVER__PORT={{ or "${QCRBOX__REGISTRY_SERVER__PORT}" .QCRBOX__REGISTRY_SERVER__PORT }}'
+    depends_on:
+      nats-server:
+        condition: process_started
+    availability:
+      restart: "always"
+
   qcrbox-client-dummy-cli:
     command: "pyqcrbox-run-registry-client services/applications/dummy_cli/config_dummy_cli.yaml"
     environment:

--- a/pyqcrbox/pyqcrbox/data_management/data_file.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_file.py
@@ -3,19 +3,22 @@ from pydantic import BaseModel
 
 class QCrBoxDataFile(BaseModel):
     qcrbox_file_id: str
-    filename: str | None
+    filename: str
+    filetype: str
     contents: bytes
 
     def to_response_model(self) -> "QCrBoxDataFileResponse":
         return QCrBoxDataFileResponse(
             qcrbox_file_id=self.qcrbox_file_id,
             filename=self.filename,
+            filetype=self.filetype,
         )
 
 
 class QCrBoxDataFileResponse(BaseModel):
     qcrbox_file_id: str
-    filename: str | None
+    filename: str
+    filetype: str
 
 
 class QCrBoxDataset(BaseModel):

--- a/pyqcrbox/pyqcrbox/data_management/data_file.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_file.py
@@ -16,3 +16,19 @@ class QCrBoxDataFile(BaseModel):
 class QCrBoxDataFileResponse(BaseModel):
     qcrbox_file_id: str
     filename: str | None
+
+
+class QCrBoxDataset(BaseModel):
+    dataset_id: str
+    data_files: list[QCrBoxDataFile]
+
+    def to_response_model(self) -> "QCrBoxDatasetResponse":
+        return QCrBoxDatasetResponse(
+            dataset_id=self.dataset_id,
+            data_files=[f.to_response_model() for f in self.data_files],
+        )
+
+
+class QCrBoxDatasetResponse(BaseModel):
+    dataset_id: str
+    data_files: list[QCrBoxDataFileResponse]

--- a/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
@@ -86,9 +86,11 @@ class DummyDataFileManager:
         _qcrbox_file_id: str | None = None,
     ) -> str:
         qcrbox_file_id = _qcrbox_file_id or generate_data_file_id()
+        file_extension = Path(filename).suffix[1:]
         data_file = QCrBoxDataFile(
             qcrbox_file_id=qcrbox_file_id,
             filename=filename,
+            filetype=file_extension,
             contents=file_contents,
         )
         self.dummy_storage[qcrbox_file_id] = data_file

--- a/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
@@ -3,12 +3,15 @@ from pathlib import Path
 import nats.js.errors
 
 from pyqcrbox import logger
-from pyqcrbox.helpers import generate_data_file_id
+from pyqcrbox.helpers import generate_data_file_id, generate_dataset_id
 
-from .data_file import QCrBoxDataFile
+from .data_file import QCrBoxDataFile, QCrBoxDataset
 
 
 class QCrBoxDataFileManager:
+    def __init__(self):
+        self.datasets = {}
+
     async def exists(self, qcrbox_file_id: str) -> bool:
         from pyqcrbox.services import get_nats_broker
 
@@ -38,6 +41,11 @@ class QCrBoxDataFileManager:
         await data_file_storage.put(qcrbox_file_id, file_contents)
         return qcrbox_file_id
 
+    async def create_dataset_from_data_file(self, data_file_id: str) -> str:
+        dataset_id = generate_dataset_id()
+        self.datasets[dataset_id] = [data_file_id]
+        return dataset_id
+
     async def get_file_contents(self, qcrbox_file_id: str) -> bytes:
         from pyqcrbox.services import get_nats_broker
 
@@ -61,6 +69,7 @@ class QCrBoxDataFileManager:
 class DummyDataFileManager:
     def __init__(self):
         self.dummy_storage = {}
+        self.datasets = {}
 
     async def exists(self, qcrbox_file_id: str) -> bool:
         return qcrbox_file_id in self.dummy_storage
@@ -86,8 +95,20 @@ class DummyDataFileManager:
 
         return qcrbox_file_id
 
+    async def create_dataset_from_data_file(self, data_file_id: str) -> str:
+        dataset_id = generate_dataset_id()
+        data_files = [await self.get_data_file(data_file_id)]
+        self.datasets[dataset_id] = QCrBoxDataset(dataset_id=dataset_id, data_files=data_files)
+        return dataset_id
+
     async def get_data_files(self) -> list[QCrBoxDataFile]:
         return list(self.dummy_storage.values())
+
+    async def get_data_file(self, data_file_id) -> QCrBoxDataFile:
+        return self.dummy_storage[data_file_id]
+
+    async def get_datasets(self) -> list[QCrBoxDataset]:
+        return list(self.datasets.values())
 
     async def get_file_contents(self, qcrbox_file_id: str) -> bytes:
         data_file = self.dummy_storage[qcrbox_file_id]

--- a/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
@@ -5,7 +5,7 @@ import nats.js.errors
 from pyqcrbox import logger
 from pyqcrbox.helpers import generate_data_file_id, generate_dataset_id
 
-from .data_file import QCrBoxDataFile, QCrBoxDataset
+from .data_file import QCrBoxDataFile, QCrBoxDataset, QCrBoxDatasetResponse
 
 
 class QCrBoxDataFileManager:
@@ -109,6 +109,9 @@ class DummyDataFileManager:
 
     async def get_datasets(self) -> list[QCrBoxDataset]:
         return list(self.datasets.values())
+
+    async def get_dataset_info(self, dataset_id: str) -> QCrBoxDatasetResponse:
+        return self.datasets[dataset_id].to_response_model()
 
     async def get_file_contents(self, qcrbox_file_id: str) -> bytes:
         data_file = self.dummy_storage[qcrbox_file_id]

--- a/pyqcrbox/pyqcrbox/helpers.py
+++ b/pyqcrbox/pyqcrbox/helpers.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 from pyqcrbox.logging import logger
 
-__all__ = ["generate_correlation_id", "generate_data_file_id", "generate_private_routing_key"]
+__all__ = ["generate_correlation_id", "generate_data_file_id", "generate_dataset_id", "generate_private_routing_key"]
 
 
 def generate_private_routing_key() -> str:
@@ -32,6 +32,12 @@ def generate_calculation_id() -> str:
 def generate_data_file_id() -> str:
     result = create_unique_id(prefix="qcrbox_df_")
     logger.debug(f"Generated data file id: {result}")
+    return result
+
+
+def generate_dataset_id() -> str:
+    result = create_unique_id(prefix="qcrbox_ds_")
+    logger.debug(f"Generated dataset id: {result}")
     return result
 
 

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -81,6 +81,11 @@ async def get_data_files() -> list[dict]:
     return await api_helpers._get_data_files()
 
 
+@get(path="/datasets", media_type=MediaType.JSON)
+async def get_datasets() -> list[dict]:
+    return await api_helpers._get_datasets()
+
+
 async def _get_data_files() -> list[dict]:
     data_file_manager = await get_data_file_manager()
     data_files = await data_file_manager.get_data_files()
@@ -119,6 +124,7 @@ api_router = Router(
         get_calculation_info,
         get_calculation_info_by_calculation_id,
         get_data_files,
+        get_datasets,
         handle_data_file_upload,
     ],
 )

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
@@ -191,7 +191,26 @@ async def _get_data_files() -> list[dict]:
     return [f.to_response_model() for f in data_files]
 
 
+async def _get_datasets() -> list[dict]:
+    data_file_manager = await get_data_file_manager()
+    datasets = await data_file_manager.get_datasets()
+    return [d.to_response_model() for d in datasets]
+
+
 async def _import_data_file(data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)]) -> str:
     data_file_manager = await get_data_file_manager()
     qcrbox_data_file_id = await data_file_manager.import_bytes(await data.read(), filename=data.filename)
     return qcrbox_data_file_id
+
+
+async def _import_dataset(data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)]) -> str:
+    data_file_manager = await get_data_file_manager()
+    qcrbox_data_file_id = await data_file_manager.import_bytes(await data.read(), filename=data.filename)
+    qcrbox_dataset_id = await data_file_manager.create_dataset_from_data_file(qcrbox_data_file_id)
+    return qcrbox_dataset_id
+
+
+async def _get_dataset_info(dataset_id: str) -> dict:
+    data_file_manager = await get_data_file_manager()
+    dataset_info = await data_file_manager.get_dataset_info(dataset_id)
+    return dataset_info.model_dump()

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadForm.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadForm.jinjax
@@ -1,0 +1,47 @@
+<div class="block">
+  <form
+     id="file_upload_form"
+     hx-encoding="multipart/form-data"
+     hx-post="/views/datasets/new"
+     hx-target="#datafile-text"
+     hx-swap="outerHTML"
+     hx-on::after-request="this.reset()"
+  >
+    <label class="label">Import data file:</label>
+    <div class="file is-small is-flex-direction-row">
+      <label class="file-label">
+        <input id="file_selector" class="file-input" type="file" name="file" required />
+        <span class="file-cta">
+          <span class="file-label"> Choose a file… </span>
+        </span>
+      </label>
+      <div
+        class="file-name"
+        _="on change from #file_selector
+              if #file_selector.value is not empty
+                 put #file_selector.files[0].name into me
+              end
+           on htmx:load from body or reset from #file_upload_form
+              put '<span style=\'color: #666\'>(No file chosen)</span>' into me
+          ">
+      </div>
+      <div>
+        <button
+          id="btn_data_file_upload"
+          class="button is-outline is-small ml-3"
+          type="submit"
+          disabled
+          script="on change from #file_selector remove @disabled
+                  on reset from #file_upload_form add @disabled"
+          data-loading-disable
+          data-loading-class="is-loading"
+        >
+          <span class="file-icon">
+            <i class="ph ph-upload"></i>
+          </span>
+            Import
+        </button>
+      </div>
+    </div>
+  </form>
+</div>

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadForm.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadForm.jinjax
@@ -6,6 +6,7 @@
      hx-target="#datafile-text"
      hx-swap="outerHTML"
      hx-on::after-request="this.reset()"
+     _="on htmx:afterRequest trigger closeModal"
   >
     <label class="label">Import data file:</label>
     <div class="file is-small is-flex-direction-row">

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
@@ -1,15 +1,15 @@
 {#def dataset_info #}
 
 {% if dataset_info.data_files | length == 1 %}
-    <div id="datafile-text">Awesome filename!</div>
+    <div id="datafile-text">{{ dataset_info.data_files[0].filename }}</div>
     <div id="metadata" hx-swap-oob="innerHTML">
-        {{ dataset_info.data_files[0].filename }}
-    </div>
-    <div id="dataset-id" hx-swap-oob="innerHTML">
         <ul>
             <li>Dataset id: <code>{{ dataset_info.dataset_id }}</code></li>
-            <li>File type: TODO</code></li>
+            <li>File type: <code>{{ dataset_info.data_files[0].filetype }}</code></li>
         </ul>
+    </div>
+    <div id="dataset-id" hx-swap-oob="innerHTML">
+        {{ dataset_info.dataset_id }}
     </div>
 
 {% elif dataset_info.data_files == [] %}

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
@@ -1,0 +1,35 @@
+{#def dataset_info #}
+
+{% if dataset_info.data_files | length == 1 %}
+    <div id="datafile-text">Awesome filename!</div>
+    <div id="metadata" hx-swap-oob="innerHTML">
+        {{ dataset_info.data_files[0].filename }}
+    </div>
+    <div id="dataset-id" hx-swap-oob="innerHTML">
+        <ul>
+            <li>Dataset id: <code>{{ dataset_info.dataset_id }}</code></li>
+            <li>File type: TODO</code></li>
+        </ul>
+    </div>
+
+{% elif dataset_info.data_files == [] %}
+    <div id="datafile-text">
+        <i>Empty dataset<i>
+    </div>
+    <div id="metadata" hx-swap-oob="innerHTML">
+        <div class="notification is-danger is-light">
+            Error: the dataset contains no data files.
+        </div>
+    </div>
+
+{% else %}
+    <div id="datafile-text">
+        <i>Multi-file dataset<i>
+    </div>
+    <div id="metadata" hx-swap-oob="innerHTML">
+        <div class="notification is-danger is-light">
+            Warning: the dataset contains multiple files, which is not currently supported.
+        </div>
+    </div>
+
+{% endif %}

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
@@ -29,13 +29,7 @@
                 <button class="delete" aria-label="close" id="close-modal"></button>
             </header>
             <section class="modal-card-body" id="modal-content">
-                <button class="button is-primary is-outlined"
-                        id="import-button"
-                        hx-post="/views/datasets/new"
-                        hx-target="#datafile-text"
-                >
-                    Import Data
-                </button>
+                <DatasetUploadForm />
             </section>
             <footer class="modal-card-foot">
             </footer>

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
@@ -29,7 +29,13 @@
                 <button class="delete" aria-label="close" id="close-modal"></button>
             </header>
             <section class="modal-card-body" id="modal-content">
-                <button class="button is-primary is-outlined" id="import-button">Import Data</button>
+                <button class="button is-primary is-outlined"
+                        id="import-button"
+                        hx-post="/views/datasets/new"
+                        hx-target="#datafile-text"
+                >
+                    Import Data
+                </button>
             </section>
             <footer class="modal-card-foot">
             </footer>

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
@@ -5,7 +5,10 @@
         <div class="column">
             <div class="box mt-3" style="display: inline-flex; align-items: center;">
                 <span class="icon" style="margin-right: 10px;">
-                    <button id="open-modal" hx-get="/modal-content" hx-target="#modal-content" hx-swap="innerHTML" style="background-color: transparent; border: none; cursor: pointer;">
+                    <button id="open-modal"
+                            style="background-color: transparent; border: none; cursor: pointer;"
+                            _="on click trigger showModal on #modal"
+                    >
                         <i class="ph-fill ph-square" style="color: #8A8A8A; font-size: 3em;"></i>
                     </button>
                 </span>
@@ -21,12 +24,19 @@
         </div>
     </div>
 
-    <div class="modal" id="modal">
+    <div class="modal"
+         id="modal"
+         _="on showModal add .is-active on closeModal remove .is-active"
+    >
         <div class="modal-background"></div>
         <div class="modal-card">
             <header class="modal-card-head">
                 <p class="modal-card-title">Import your data</p>
-                <button class="delete" aria-label="close" id="close-modal"></button>
+                <button class="delete"
+                        aria-label="close"
+                        id="close-modal"
+                        _="on click trigger closeModal"
+                ></button>
             </header>
             <section class="modal-card-body" id="modal-content">
                 <DatasetUploadForm />
@@ -35,32 +45,5 @@
             </footer>
         </div>
     </div>
-
-    <script>
-        document.getElementById('open-modal').onclick = function () {
-            document.getElementById('modal').style.display = 'block';
-        };
-
-        document.getElementById('close-modal').onclick = function () {
-            document.getElementById('modal').style.display = 'none';
-        };
-
-        document.querySelector('.modal-background').onclick = function () {
-            document.getElementById('modal').style.display = 'none';
-        };
-
-        // Close the modal when the "Import" button is clicked
-        document.getElementById('import-button').onclick = function () {
-            document.getElementById('modal').style.display = 'none';
-
-            // Replace the text "Click the grey box to select a datafile" with "Datafile"
-            document.getElementById('datafile-text').textContent = 'Filename';
-            document.getElementById('metadata').textContent = 'Metadata';
-
-            // Change the color of the icon to black
-            document.querySelector('.ph-fill.ph-square').style.color = '#000000';
-
-        };
-    </script>
 
 </MainLayout>

--- a/pyqcrbox/pyqcrbox/registry/server/views/view_handlers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/views/view_handlers.py
@@ -50,15 +50,20 @@ async def serve_data_files_page() -> Response:
 
 
 @post(path="/data_files/upload", media_type=MediaType.TEXT)
-async def handle_data_file_upload(data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)]) -> str:
+async def handle_data_file_upload(
+    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
+) -> Response:
     _qcrbox_data_file_id = await api_helpers._import_data_file(data)
     return render("DataFilesList", data_files=await api_helpers._get_data_files())
 
 
-@post(path="/datasets/upload", media_type=MediaType.TEXT)
-async def handle_dataset_upload(data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)]) -> str:
-    _qcrbox_dataset_id = await api_helpers._import_dataset(data)
-    return render("DatasetInfo", dataset=await api_helpers._get_dataset_info(_qcrbox_dataset_id))
+@post(path="/datasets/new", media_type=MediaType.TEXT)
+async def handle_dataset_upload(
+    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
+) -> Response:
+    dataset_id = await api_helpers._import_dataset(data)
+    dataset_info = await api_helpers._get_dataset_info(dataset_id)
+    return render("DatasetUploadResponse", dataset_info=dataset_info)
 
 
 views_router = Router(

--- a/pyqcrbox/pyqcrbox/registry/server/views/view_handlers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/views/view_handlers.py
@@ -55,6 +55,12 @@ async def handle_data_file_upload(data: Annotated[UploadFile, Body(media_type=Re
     return render("DataFilesList", data_files=await api_helpers._get_data_files())
 
 
+@post(path="/datasets/upload", media_type=MediaType.TEXT)
+async def handle_dataset_upload(data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)]) -> str:
+    _qcrbox_dataset_id = await api_helpers._import_dataset(data)
+    return render("DatasetInfo", dataset=await api_helpers._get_dataset_info(_qcrbox_dataset_id))
+
+
 views_router = Router(
     path="/views",
     route_handlers=[
@@ -62,6 +68,7 @@ views_router = Router(
         serve_applications_page,
         serve_data_files_page,
         handle_data_file_upload,
+        handle_dataset_upload,
         get_command_details,
     ],
 )


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Resolves #353 


## Summary of the changes

- Added request handler for `views//datasets/new`, which returns a response providing the filename, metadata and object id for the frontend.
- TODO: describe the remaining changes

## How was it tested?

The request handler for `/views/datasets/new` was tested using Postman (with visual inspection of the htmx response).

I also tested the changes to the landing page interactively by starting qcrbox dev server, navigating to the landing page and interacting with the page elements.


## Additional considerations / follow-up work needed

In order to test whether the landing page elements are updated correctly by the html snippets returned in the response, I needed to make some changes to the frontend elements, which may address #344 (at least partly). @phillybroadbent Please let me know if this conflicts with any work you have done and I can either remove it or we can merge them together.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [X] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~
