### PR TITLE
Add dummy GUI application for testing of interactive sessions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,8 @@ However, there will be an initial period of stabilisation where this is not adhe
 
 ### Development
 
+- Added dummy GUI application for testing of interactive sessions. ([#364](https://github.com/QCrBox/QCrBox/issues/364))
+
 
 ### Documentation
 

--- a/services/applications/dummy_gui/dummy_gui.py
+++ b/services/applications/dummy_gui/dummy_gui.py
@@ -6,24 +6,31 @@ from pathlib import Path
 from tkinter import ttk
 
 
+def add_labels(frame, input_args):
+    try:
+        input_filepath = Path(input_args[0])
+        input_filename = input_filepath.name
+        ttk.Label(frame, text=f"Input file specified: {input_filename!r}\n", justify=tk.LEFT).pack(fill=tk.X)
+        if not input_filepath.exists():
+            ttk.Label(frame, text=f"Error: input file {input_filename!r} does not exist", justify=tk.LEFT).pack(
+                fill=tk.X
+            )
+    except IndexError:
+        ttk.Label(frame, text="No input file specified.").pack()
+
+
 def main():
     root = tk.Tk()
     root.title("Dummy GUI Application")
-    root.minsize(400, 200)
-    frm = ttk.Frame(root, padding=10)
-    frm.grid()
+    root.minsize(400, 0)
+    frame = ttk.Frame(root, padding=10)
+    frame.grid()
 
-    try:
-        input_filepath = Path(sys.argv[1])
-        input_filename = input_filepath.name
-        ttk.Label(frm, text=f"Input file specified: {input_filename!r}\n", justify=tk.LEFT).pack(fill=tk.X)
-        if not input_filepath.exists():
-            ttk.Label(frm, text=f"Error: input file {input_filename!r} does not exist", justify=tk.LEFT).pack(fill=tk.X)
-    except IndexError:
-        ttk.Label(frm, text="No input file specified.").pack()
+    input_args = sys.argv[1:]
+    add_labels(frame, input_args)
 
-    ttk.Label(frm, text="").pack()
-    ttk.Button(frm, text="Quit", command=root.destroy).pack()
+    ttk.Button(frame, text="Quit", command=root.destroy).pack(pady=(20, 10))
+
     root.mainloop()
 
 

--- a/services/applications/dummy_gui/dummy_gui.py
+++ b/services/applications/dummy_gui/dummy_gui.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import sys
+import tkinter as tk
+from pathlib import Path
+from tkinter import ttk
+
+
+def main():
+    root = tk.Tk()
+    root.title("Dummy GUI Application")
+    root.minsize(400, 200)
+    frm = ttk.Frame(root, padding=10)
+    frm.grid()
+
+    try:
+        input_filepath = Path(sys.argv[1])
+        input_filename = input_filepath.name
+        ttk.Label(frm, text=f"Input file specified: {input_filename!r}\n", justify=tk.LEFT).pack(fill=tk.X)
+        if not input_filepath.exists():
+            ttk.Label(frm, text=f"Error: input file {input_filename!r} does not exist", justify=tk.LEFT).pack(fill=tk.X)
+    except IndexError:
+        ttk.Label(frm, text="No input file specified.").pack()
+
+    ttk.Label(frm, text="").pack()
+    ttk.Button(frm, text="Quit", command=root.destroy).pack()
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Resolves #364 


## Summary of the changes

This PR adds the Python script `services/applications/dummy_gui/dummy_gui.py` which opens a minimal GUI window displaying some information about the input argument given.


## How was it tested?

Tested interactively by running the script with different inputs:
```bash
# No input file given
$ python dummy_gui.py

# Non-existent input file
$ python dummy_gui.py gobbledygook.txt

# Pass 'dummy_gui.py' itself as input file (which is guaranteed to exist)
$ python dummy_gui.py dummy_gui.py
```


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [X] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [X] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~
