### PR TITLE
Interactive session UI elements

### DIFF
--- a/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
@@ -85,7 +85,9 @@
                         </a>
                     </li>
                 </ul>
-                <button class="button is-dark m-3" style="background-color: #417890;">Start Interactive Session</button>
+                <a href="http://localhost:12004/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true" target="_blank">
+                    <button class="button is-dark m-3" style="background-color: #417890;">Start Interactive Session</button>
+                </a>
             </div>
             `;
         } 

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/DatasetUploadResponse.jinjax
@@ -18,7 +18,12 @@
         </span>
         <div style="width: 100px; height: 3px; background-color: #417890; margin: 0 10px;"></div>
         <div class="box m-3" style="border: 2px solid #417890; padding: 10px;">
-            <select id="select-application" name="application">
+            <select 
+                id="select-application" 
+                name="application" 
+                hx-get="/views/view_start_session_button" 
+                hx-target="#start-button" 
+                hx-trigger="change">
                 <option value="" disabled selected hidden>Please select an application</option>
                 {% if applications %}
                     {% for application in applications %}
@@ -75,7 +80,7 @@
         // If a valid application is selected, construct the HTML content
         if (appName && appVersion && appRegistered) {
             metadataBox.outerHTML = `
-            <div id="metadata" class="box mt-3" style="border: 2px solid #417890; padding: 10px;">
+            <div id="metadata">
                 <h3 class="title is-4">${appName}</h3>
                 <ul class="list" style="list-style-type: disc; padding-left: 20px;">
                     <li>Version: ${appVersion}</li>
@@ -85,9 +90,6 @@
                         </a>
                     </li>
                 </ul>
-                <a href="http://localhost:12004/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true" target="_blank">
-                    <button class="button is-dark m-3" style="background-color: #417890;">Start Interactive Session</button>
-                </a>
             </div>
             `;
         } 

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/QCrBoxHomePage.jinjax
@@ -21,8 +21,14 @@
         </div>
 
         <div class="column">
-            <div id="metadata" class="box mt-3" style="border: 2px solid #417890; padding: 10px;">
-                Information about the data file.
+            <div class="box mt-3" style="border: 2px solid #417890; padding: 10px;">
+                <div id="metadata">
+                    Information about the data file.
+                </div>
+                <div id="start-button">
+                </div>
+                <div id="stop-button">
+                </div>
             </div>
         </div>
     </div>
@@ -50,3 +56,19 @@
     </div>
 
 </MainLayout>
+
+<script>
+    let olexTab; // Variable to store the reference to the opened tab
+
+    function openOlexTab() {
+        // Open the URL in a new tab and store the reference
+        olexTab = window.open("http://localhost:12004/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true", '_blank');
+    }
+
+    function closeVncTab() {
+        // Close the tab if it's open
+        if (olexTab && !olexTab.closed) {
+            olexTab.close();
+        }
+    }
+</script>

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/StartInteractiveSessionButton.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/StartInteractiveSessionButton.jinjax
@@ -1,0 +1,8 @@
+<button 
+    class="button is-dark m-3" style="background-color: #417890;" 
+    hx-get="/views/start_session"
+    hx-target="#stop-button"
+    hx-swap="innerHTML"
+    onclick="openOlexTab()">
+    Start Interactive Session
+</button>

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/StartSessionResponse.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/StartSessionResponse.jinjax
@@ -1,0 +1,3 @@
+<button class="button is-light m-3">
+    Stop Interactive Session
+</button>

--- a/pyqcrbox/pyqcrbox/registry/server/views/components/StartSessionResponse.jinjax
+++ b/pyqcrbox/pyqcrbox/registry/server/views/components/StartSessionResponse.jinjax
@@ -1,3 +1,3 @@
-<button class="button is-light m-3">
+<button class="button is-light m-3" onclick="closeVncTab()">
     Stop Interactive Session
 </button>

--- a/pyqcrbox/pyqcrbox/registry/server/views/view_handlers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/views/view_handlers.py
@@ -67,6 +67,16 @@ async def handle_dataset_upload(
     return render("DatasetUploadResponse", dataset_info=dataset_info, applications=applications)
 
 
+@get(path="/start_session")
+async def start_interactive_session() -> Response:
+    return render("StartSessionResponse")
+
+
+@get(path="/view_start_session_button")
+async def view_interactive_session_button() -> Response:
+    return render("StartInteractiveSessionButton")
+
+
 views_router = Router(
     path="/views",
     route_handlers=[
@@ -76,5 +86,7 @@ views_router = Router(
         handle_data_file_upload,
         handle_dataset_upload,
         get_command_details,
+        start_interactive_session,
+        view_interactive_session_button,
     ],
 )


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Partially resolves #347 and #348. 


## Summary of the changes
The buttons for opening and closing the olex2 GUI have been added. At the moment, the buttons open and close the olex2 tab and call example api endpoints. These elements can be used for testing #345 and #354.  The sample api endpoints should be switched for the real endpoints when these are available. 


## How was it tested?
Through the user interface.


## Additional considerations / follow-up work needed


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~
