### PR TITLE
Fix missing dependency

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 ### Issues Fixed
 
 - Fixed an error when running `qcb build`. ([#335](https://github.com/QCrBox/QCrBox/issues/335))
+- Fixed missing dependency, leading to startup errors. ([#368](https://github.com/QCrBox/QCrBox/issues/368))
 
 ### Development
 

--- a/pyqcrbox/pyproject.toml
+++ b/pyqcrbox/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pydantic",
     "pydantic-settings",
     "rich",
+    "setuptools_scm",
     "sqlmodel",
     "svcs",
     "stamina",
@@ -42,7 +43,6 @@ dev = [
     "requests",
     "reuse",
     "ruff",
-    "setuptools_scm",
     #
     # linting
     "import-linter",


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #368 


## Summary of the changes

Moved the `setuptools_scm` module from optional dependencies into required dependencies.

## How was it tested?

Interactively by running `qcb up qcrbox-registry` and checking the Docker log messages.


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [X] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [X] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~