### PR TITLE
Input frame folder kw

### DIFF
--- a/docs/tutorials/examples/example_cod.ipynb
+++ b/docs/tutorials/examples/example_cod.ipynb
@@ -145,7 +145,9 @@
     "shutil.copy(\"./input_files/cap_result.cif\", folder_test / \"input.cif\")\n",
     "\n",
     "calc = cod.get_number_fitting_cod_entries(\n",
-    "    input_cif_path=path_qcrbox / \"example_count\" / \"input.cif\", cellpar_deviation_perc=5.0, listed_elements_only=True\n",
+    "    input_cif_path=path_qcrbox / \"example_count\" / \"input.cif\",\n",
+    "    cellpar_deviation_perc=5.0,\n",
+    "    listed_elements_only=True,\n",
     ")\n",
     "\n",
     "calc.wait_while_running(0.5)"

--- a/docs/tutorials/examples/example_crysalis_pro.ipynb
+++ b/docs/tutorials/examples/example_crysalis_pro.ipynb
@@ -146,6 +146,7 @@
    "outputs": [],
    "source": [
     "session = crysalis_pro.interactive_session(\n",
+    "    input_folder=path_qcrbox / \"run_interactive\" / \"Ylid_Mo_RT\",\n",
     "    par_path=path_qcrbox / \"run_interactive\" / \"Ylid_Mo_RT/Ylid_Mo_RT.run\",\n",
     "    output_cif_path=path_qcrbox / \"run_interactive\" / \"Ylid_Mo_RT\" / \"qcrbox_output.cif\",\n",
     ")\n",
@@ -185,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/examples/example_eval.ipynb
+++ b/docs/tutorials/examples/example_eval.ipynb
@@ -184,7 +184,7 @@
     "You do not need to set the pointgroup with pg\n",
     "\n",
     "#### sadabs and shellscript-3\n",
-    "sadabs is not independent of eval and therefore not available within the container."
+    "sadabs is not freely available and therefore not included within the container."
    ]
   },
   {
@@ -194,7 +194,7 @@
    "outputs": [],
    "source": [
     "session = eval1x.interactive_session(\n",
-    "    work_folder=path_qcrbox / \"run_interactive\",\n",
+    "    input_folder=path_qcrbox / \"run_interactive\",\n",
     "    output_cif_path=path_qcrbox / \"run_interactive\" / \"output.cif\",\n",
     ")\n",
     "session.start()"
@@ -255,7 +255,7 @@
    "outputs": [],
    "source": [
     "calc2 = eval1x.integrate(\n",
-    "    work_folder=path_qcrbox / \"run_integrate\",\n",
+    "    input_folder=path_qcrbox / \"run_integrate\",\n",
     "    output_cif_path=path_qcrbox / \"run_integrate\" / \"output.cif\",\n",
     "    rmat_file_path=source_folder / \"output.cif\",\n",
     "    beamstop_file_path=source_folder / \"beamstop.vic\",\n",
@@ -278,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc2.status"
+    "calc2.status\n"
    ]
   },
   {
@@ -305,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/examples/example_eval.ipynb
+++ b/docs/tutorials/examples/example_eval.ipynb
@@ -278,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc2.status\n"
+    "calc2.status"
    ]
   },
   {

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -16,6 +16,7 @@ _known_dtypes = {
     "QCrBox.output_cif": str,
     "QCrBox.work_cif": str,
     "QCrBox.folder_path": str,
+    "QCrBox.input_folder": str,
     "QCrBox.input_file": str,
     "QCrBox.output_file": str,
 }

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/filesystem_path_parameters.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/filesystem_path_parameters.py
@@ -1,9 +1,9 @@
 from typing import Literal
 
-from .base_parameter_spec import BaseParameterSpec
-from ..cif_entry_set import OneOfCifEntrySpec, CifEntryLiteral
 from pydantic import validator
 
+from ..cif_entry_set import CifEntryLiteral, OneOfCifEntrySpec
+from .base_parameter_spec import BaseParameterSpec
 
 __all__ = [
     "FolderPathParameterSpec",
@@ -26,13 +26,17 @@ class GenericOutputFileParameterSpec(BaseFilesystemPathParameterSpec):
     dtype: Literal["QCrBox.output_file"]
 
 
+class InputFolderParameterSpec(BaseFilesystemPathParameterSpec):
+    dtype: Literal["QCrBox.input_folder"]
+
+
 class FolderPathParameterSpec(BaseFilesystemPathParameterSpec):
     dtype: Literal["QCrBox.folder_path"]
 
 
 class BaseCifFileParameterSpec(BaseFilesystemPathParameterSpec):
-    required_entries: list[CifEntryLiteral|OneOfCifEntrySpec] = []
-    optional_entries: list[CifEntryLiteral|OneOfCifEntrySpec] = []
+    required_entries: list[CifEntryLiteral | OneOfCifEntrySpec] = []
+    optional_entries: list[CifEntryLiteral | OneOfCifEntrySpec] = []
     required_entry_sets: list[str] = []
     optional_entry_sets: list[str] = []
     merge_su: bool = False

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
@@ -10,6 +10,7 @@ from .filesystem_path_parameters import (
     GenericInputFileParameterSpec,
     GenericOutputFileParameterSpec,
     InputCifParameterSpec,
+    InputFolderParameterSpec,
     OutputCifParameterSpec,
     WorkCifParameterSpec,
 )
@@ -34,6 +35,7 @@ ParameterSpecTaggedUnion = Union[
     Annotated[GenericOutputFileParameterSpec, Tag("QCrBox.output_file")],
     Annotated[WorkCifParameterSpec, Tag("QCrBox.work_cif")],
     Annotated[FolderPathParameterSpec, Tag("QCrBox.folder_path")],
+    Annotated[InputFolderParameterSpec, Tag("QCrBox.input_folder")],
 ]
 ParameterSpecDiscriminatedUnion = Annotated[ParameterSpecTaggedUnion, Field(discriminator="dtype")]
 

--- a/services/applications/crysalis-pro/CrysAlisPro171.44.48a.exe:SmartScreen
+++ b/services/applications/crysalis-pro/CrysAlisPro171.44.48a.exe:SmartScreen
@@ -1,1 +1,0 @@
-Anaheim

--- a/services/applications/crysalis-pro/Dockerfile
+++ b/services/applications/crysalis-pro/Dockerfile
@@ -19,11 +19,10 @@ ENV WINEARCH=${WINEARCH}
 ENV QCRBOX_ROOT_DIR=${QCRBOX_ROOT_DIR}
 
 COPY --chown=${QCRBOX_USER}:${QCRBOX_USER} ./.idesktop ./.idesktop
-
-RUN gosu ${QCRBOX_USER} bash -x ${QCRBOX_ROOT_DIR}/run_crysalis_pro_setup_if_not_yet_installed.sh
-
 COPY configure_crysalis-pro.py ./
 COPY config_crysalis-pro.yaml ./
+
+RUN gosu ${QCRBOX_USER} bash -x ${QCRBOX_ROOT_DIR}/run_crysalis_pro_setup_if_not_yet_installed.sh
 
 ENV PATH="$PATH:/opt/crysalis-pro/bin/"
 

--- a/services/applications/crysalis-pro/config_crysalis-pro.yaml
+++ b/services/applications/crysalis-pro/config_crysalis-pro.yaml
@@ -30,7 +30,7 @@ commands:
     interactive_lifecycle:
       run:
         implemented_as: "cli_command"
-        call_pattern: "wine /opt/wine_installations/wine_win64/drive_c/Xcalibur/CrysAlisPro171.44.48a/pro.exe {par_path}"
+        call_pattern: "wine BASH_REPLACED_CRYSALISPRO_PATH_PLACEHOLDER {par_path}"
         used_basecommand_parameters: ["par_path"]
       finalise:
         implemented_as: "python_callable"

--- a/services/applications/crysalis-pro/config_crysalis-pro.yaml
+++ b/services/applications/crysalis-pro/config_crysalis-pro.yaml
@@ -12,6 +12,10 @@ commands:
     implemented_as: "interactive"
     description: "Run CrysalisPro interactively"
     parameters:
+      - name: "input_folder"
+        dtype: "QCrBox.input_folder"
+        default_value: None
+        description: "Path to the directory containing all the necessary files (frames and other) for the CAP integration."
       - name: "par_path"
         dtype: "QCrBox.input_file"
         default_value: None
@@ -26,7 +30,7 @@ commands:
     interactive_lifecycle:
       run:
         implemented_as: "cli_command"
-        call_pattern: "wine /opt/wine_installations/wine_win64/drive_c/Xcalibur/CrysAlisPro171.43.48a/pro.exe {par_path}"
+        call_pattern: "wine /opt/wine_installations/wine_win64/drive_c/Xcalibur/CrysAlisPro171.44.48a/pro.exe {par_path}"
         used_basecommand_parameters: ["par_path"]
       finalise:
         implemented_as: "python_callable"

--- a/services/applications/crysalis-pro/run_crysalis_pro_setup_if_not_yet_installed.sh
+++ b/services/applications/crysalis-pro/run_crysalis_pro_setup_if_not_yet_installed.sh
@@ -30,6 +30,8 @@ wine ${NEW_CRYSALIS_PRO_INSTALLER} /S /v/qn
 
 NEW_CRYSALIS_PRO_EXECUTABLE=$(find ${WINEPREFIX}/drive_c/Xcalibur/CrysAlisPro* -name pro.exe -print -quit || true)
 
+sed -i "s%BASH_REPLACED_CRYSALISPRO_PATH_PLACEHOLDER%${NEW_CRYSALIS_PRO_EXECUTABLE}%g" "config_crysalis-pro.yaml"
+
 wine ${NEW_CRYSALIS_PRO_EXECUTABLE} &
 
 until xdotool search --name "Choose*"

--- a/services/applications/eval1x/config_eval1x.yaml
+++ b/services/applications/eval1x/config_eval1x.yaml
@@ -13,8 +13,8 @@ commands:
     implemented_as: "interactive"
     description: "Run the Eval Software Suite interactively"
     parameters:
-      - name: "work_folder"
-        dtype: "QCrBox.folder_path"
+      - name: "input_folder"
+        dtype: "QCrBox.input_folder"
         description: "The folder containing the images / data"
       - name: "output_cif_path"
         dtype: "QCrBox.output_cif"
@@ -26,21 +26,21 @@ commands:
     interactive_lifecycle:
       run:
         implemented_as: "cli_command"
-        call_pattern: "lxterminal --working-directory={work_folder}"
-        used_basecommand_parameters: ["work_folder"]
+        call_pattern: "lxterminal --working-directory={input_folder}"
+        used_basecommand_parameters: ["input_folder"]
       finalise:
         implemented_as: "python_callable"
         import_path: "configure_eval1x"
         callable_name: "finalise__interactive"
-        used_basecommand_parameters: ["work_folder", "output_cif_path"]
+        used_basecommand_parameters: ["input_folder", "output_cif_path"]
 
   - name: "integrate"
     implemented_as: "python_callable"
     description: "Run the Eval Software Suite programs automatically one after the other"
     import_path: "configure_eval1x"
     parameters:
-      - name: "work_folder"
-        dtype: "QCrBox.folder_path"
+      - name: "input_folder"
+        dtype: "QCrBox.input_folder"
         default_value: None
         description: "The folder containing the images / data"
       - name: "output_cif_path"

--- a/services/applications/eval1x/configure_eval1x.py
+++ b/services/applications/eval1x/configure_eval1x.py
@@ -23,7 +23,7 @@ from pyqcrbox.registry.client import QCrBoxClient
 YAML_PATH = "./config_eval1x.yaml"
 
 def integrate(
-    work_folder,
+    input_folder,
     output_cif_path,
     rmat_file_path,
     beamstop_file_path,
@@ -36,15 +36,15 @@ def integrate(
     min_refln_in_box,
     pic_dir,
 ):
-    work_folder = Path(work_folder)
+    input_folder = Path(input_folder)
     rmat_file = Path(rmat_file_path)
     if rmat_file.suffix == ".cif":
         new_rmat = RmatFile.from_cif_file("ic.rmat", rmat_file_path)
-        new_rmat.to_file(work_folder)
-        rmat_file_path = Path(work_folder) / new_rmat.filename
+        new_rmat.to_file(input_folder)
+        rmat_file_path = Path(input_folder) / new_rmat.filename
 
     builddatcol(
-        work_folder,
+        input_folder,
         rmat_file_path,
         beamstop_file_path,
         detalign_file_path,
@@ -57,30 +57,30 @@ def integrate(
     )
 
     create_shoes(
-        work_folder,
+        input_folder,
         rmat_file_path,
         beamstop_file_path,
         detalign_file_path,
-        datcol_dir=work_folder,
+        datcol_dir=input_folder,
     )
 
-    eval15all(work_folder, pic_dir)
+    eval15all(input_folder, pic_dir)
 
-    create_reflection_cif(work_folder)
+    create_reflection_cif(input_folder)
 
-    final_cell_refinement(work_folder, rmat_file_path)
+    final_cell_refinement(input_folder, rmat_file_path)
 
     merge_cif_files(
-        work_folder / "intensities.cif",
+        input_folder / "intensities.cif",
         "0",
-        work_folder / "cell.cif",
+        input_folder / "cell.cif",
         "0",
-        work_folder / "merged_eval.cif",
+        input_folder / "merged_eval.cif",
         "output",
     )
 
     cif_file_merge_to_unified_by_yml(
-        work_folder / "merged_eval.cif",
+        input_folder / "merged_eval.cif",
         output_cif_path,
         None,
         YAML_PATH,
@@ -90,7 +90,7 @@ def integrate(
 
 
 def builddatcol(
-    work_folder: str,
+    input_folder: str,
     rmat_file_path: str,
     beamstop_file_path: str,
     detalign_file_path: str,
@@ -101,20 +101,20 @@ def builddatcol(
     maximum_duration: float,
     min_refln_in_box: int,
 ):
-    work_folder = Path(work_folder)
-    if rmat_file_path == "work_folder":
-        rmat_file_path = next(reversed(sorted(work_folder.glob("*.rmat"), key=os.path.getmtime)))
-    if beamstop_file_path != "work_folder":
+    input_folder = Path(input_folder)
+    if rmat_file_path == "input_folder":
+        rmat_file_path = next(reversed(sorted(input_folder.glob("*.rmat"), key=os.path.getmtime)))
+    if beamstop_file_path != "input_folder":
         try:
-            shutil.copy(beamstop_file_path, work_folder)
+            shutil.copy(beamstop_file_path, input_folder)
         except shutil.SameFileError:
             pass
-    if detalign_file_path != "work_folder":
+    if detalign_file_path != "input_folder":
         try:
-            shutil.copy(detalign_file_path, work_folder)
+            shutil.copy(detalign_file_path, input_folder)
         except shutil.SameFileError:
             pass
-    builddatcolrob = EvalBuilddatcolRobot(work_folder=work_folder)
+    builddatcolrob = EvalBuilddatcolRobot(input_folder=input_folder)
     builddatcolrob.create_datcol_files(
         rmat_file=RmatFile.from_file(rmat_file_path),
         maximum_res=float(maximum_res),
@@ -127,21 +127,21 @@ def builddatcol(
 
 
 def create_shoes(
-    work_folder: str,
+    input_folder: str,
     rmat_file_path: str,
     beamstop_file_path: str,
     detalign_file_path: str,
     datcol_dir: str,
 ):
-    work_folder = Path(work_folder)
-    if rmat_file_path == "work_folder":
-        rmat_file_path = next(reversed(sorted(work_folder.glob("*.rmat"), key=os.path.getmtime)))
-    if beamstop_file_path == "work_folder":
-        beamstop_file_path = next(reversed(sorted(work_folder.glob("beamstop.vic"), key=os.path.getmtime)))
-    if detalign_file_path == "work_folder":
-        detalign_file_path = next(reversed(sorted(work_folder.glob("detalign.vic"), key=os.path.getmtime)))
-    if datcol_dir == "work_folder":
-        datcol_dir = work_folder
+    input_folder = Path(input_folder)
+    if rmat_file_path == "input_folder":
+        rmat_file_path = next(reversed(sorted(input_folder.glob("*.rmat"), key=os.path.getmtime)))
+    if beamstop_file_path == "input_folder":
+        beamstop_file_path = next(reversed(sorted(input_folder.glob("beamstop.vic"), key=os.path.getmtime)))
+    if detalign_file_path == "input_folder":
+        detalign_file_path = next(reversed(sorted(input_folder.glob("detalign.vic"), key=os.path.getmtime)))
+    if datcol_dir == "input_folder":
+        datcol_dir = input_folder
     else:
         datcol_dir = Path(datcol_dir)
 
@@ -153,7 +153,7 @@ def create_shoes(
     datcol_files = [TextFile.from_file(path) for path in datcol_filepaths]
 
     evalview = EvalViewRobot(
-        work_folder=work_folder,
+        input_folder=input_folder,
         file_list=[rmat_file, beamstop_file, detalign_file, *datcol_files],
     )
 
@@ -161,7 +161,7 @@ def create_shoes(
 
 
 # def buildeval15(
-#     work_folder,
+#     input_folder,
 #     focus_type,
 #     polarisation_type,
 #     pointspread_gamma,
@@ -169,7 +169,7 @@ def create_shoes(
 #     crystal_dimension,
 #     mosaic
 # ):
-#     buildeval15rob = EvalBuildeval15Robot(work_folder=work_folder)
+#     buildeval15rob = EvalBuildeval15Robot(input_folder=input_folder)
 #     buildeval15rob.run(
 #         focus_type,
 #         polarisation_type,
@@ -180,66 +180,66 @@ def create_shoes(
 #     )
 
 
-def eval15all(work_folder, pic_dir):
-    work_folder = Path(work_folder)
-    if pic_dir == "work_folder":
-        pic_dir = work_folder
+def eval15all(input_folder, pic_dir):
+    input_folder = Path(input_folder)
+    if pic_dir == "input_folder":
+        pic_dir = input_folder
     else:
         pic_dir = Path(pic_dir)
     pic_files = [PicFile.from_file(path) for path in pic_dir.glob("*.pic")]
 
     if len(pic_files) == 0 and (pic_dir / "ic").exists():
         pic_files = [PicFile.from_file(path) for path in pic_dir.glob("ic/*.pic")]
-    if len(list(work_folder.glob("*.sho*"))) == 0 and (work_folder / "ic").exists():
-        work_folder = work_folder / "ic"
+    if len(list(input_folder.glob("*.sho*"))) == 0 and (input_folder / "ic").exists():
+        input_folder = input_folder / "ic"
 
-    eval15 = Eval15AllRobot(work_folder=work_folder, file_list=pic_files)
+    eval15 = Eval15AllRobot(input_folder=input_folder, file_list=pic_files)
 
     eval15.integrate_shoes()
 
 
-def create_reflection_cif(work_folder):
-    work_folder = Path(work_folder)
+def create_reflection_cif(input_folder):
+    input_folder = Path(input_folder)
 
-    if (work_folder / "ic").exists():
-        anyrob = EvalAnyRobot(work_folder=work_folder / "ic")
+    if (input_folder / "ic").exists():
+        anyrob = EvalAnyRobot(input_folder=input_folder / "ic")
     else:
-        anyrob = EvalAnyRobot(work_folder=work_folder)
+        anyrob = EvalAnyRobot(input_folder=input_folder)
 
-    anyrob.create_cif_file(work_folder / "intensities.cif")
+    anyrob.create_cif_file(input_folder / "intensities.cif")
 
 
-def final_cell_refinement(work_folder, rmat_file_path):
-    work_folder = Path(work_folder)
-    if rmat_file_path == "work_folder":
-        rmat_file_path = next(reversed(sorted(work_folder.glob("*.rmat"), key=os.path.getmtime)))
+def final_cell_refinement(input_folder, rmat_file_path):
+    input_folder = Path(input_folder)
+    if rmat_file_path == "input_folder":
+        rmat_file_path = next(reversed(sorted(input_folder.glob("*.rmat"), key=os.path.getmtime)))
 
-    anyrob = EvalAnyRobot(work_folder=work_folder / "ic")
+    anyrob = EvalAnyRobot(input_folder=input_folder / "ic")
     anyrob.create_pk()
 
-    peakref = EvalPeakrefRobot(work_folder=work_folder, rmat_file=RmatFile.from_file(rmat_file_path))
+    peakref = EvalPeakrefRobot(input_folder=input_folder, rmat_file=RmatFile.from_file(rmat_file_path))
 
     peakref.refine_parameters("ic/final", new_rmat_filename="ic_refined.rmat", end_with_cell=True)
 
     peakref.folder_to_cif("cell.cif")
 
 
-def finalise__interactive(work_folder, output_cif_path):
-    work_folder = Path(work_folder)
-    create_reflection_cif(work_folder)
-    final_cell_refinement(work_folder, "work_folder")
+def finalise__interactive(input_folder, output_cif_path):
+    input_folder = Path(input_folder)
+    create_reflection_cif(input_folder)
+    final_cell_refinement(input_folder, "input_folder")
 
     merge_cif_files(
-        work_folder / "intensities.cif",
+        input_folder / "intensities.cif",
         "0",
-        work_folder / "cell.cif",
+        input_folder / "cell.cif",
         "0",
-        work_folder / "merged_eval.cif",
+        input_folder / "merged_eval.cif",
         "output",
     )
 
     cif_file_merge_to_unified_by_yml(
-        work_folder / "merged_eval.cif",
+        input_folder / "merged_eval.cif",
         output_cif_path,
         None,
         YAML_PATH,
@@ -248,38 +248,38 @@ def finalise__interactive(work_folder, output_cif_path):
     )
 
 
-def toparams__interactive(work_folder, par_json, par_folder):
-    work_folder = Path(work_folder)
+def toparams__interactive(input_folder, par_json, par_folder):
+    input_folder = Path(input_folder)
     par_folder = Path(par_folder)
     # TODO Check if par_folder is empty?
 
-    bdatcol = EvalBuilddatcolRobot(work_folder)
+    bdatcol = EvalBuilddatcolRobot(input_folder)
     tojson = bdatcol.extract_vars()
 
-    output_cif_in = work_folder / "output.cif"
+    output_cif_in = input_folder / "output.cif"
     output_cif_save = par_folder / "output.cif"
     if output_cif_in.exists():
         shutil.copy(output_cif_in, output_cif_save)
     else:
-        rmat_file_path = next(reversed(sorted(work_folder.glob("*.rmat"), key=os.path.getmtime)))
+        rmat_file_path = next(reversed(sorted(input_folder.glob("*.rmat"), key=os.path.getmtime)))
         rmat = RmatFile.from_file(rmat_file_path)
         rmat.to_cif_file(output_cif_save, "output")
 
     tojson["rmat_file_path"] = "$par_folder/output.cif"
 
-    beamstop_file_path = next(reversed(sorted(work_folder.glob("beamstop.vic"), key=os.path.getmtime)))
+    beamstop_file_path = next(reversed(sorted(input_folder.glob("beamstop.vic"), key=os.path.getmtime)))
 
     shutil.copy(beamstop_file_path, par_folder / "beamstop.vic")
 
     tojson["beamstop_file_path"] = "$par_folder/beamstop.vic"
 
-    detalign_file_path = next(reversed(sorted(work_folder.glob("detalign.vic"), key=os.path.getmtime)))
+    detalign_file_path = next(reversed(sorted(input_folder.glob("detalign.vic"), key=os.path.getmtime)))
 
     shutil.copy(detalign_file_path, par_folder / "detalign.vic")
 
     tojson["detalign_file_path"] = "$par_folder/detalign.vic"
 
-    pic_files_info = [(file.stat().st_mtime, file.parent) for file in work_folder.rglob("*.pic")]
+    pic_files_info = [(file.stat().st_mtime, file.parent) for file in input_folder.rglob("*.pic")]
     pic_folder_in = sorted(pic_files_info, key=lambda x: x[0], reverse=True)[0][1]
     pic_folder_out = par_folder / "pic_dir"
     pic_folder_out.mkdir(exist_ok=True)
@@ -293,13 +293,13 @@ def toparams__interactive(work_folder, par_json, par_folder):
         json.dump(tojson, fobj, indent=4)
 
 
-def redo__interactive(work_folder, par_json, par_folder):
+def redo__interactive(input_folder, par_json, par_folder):
     with open(par_json, "r", encoding="UTF-8") as fobj:
         par_dict = json.load(fobj)
     for key in par_dict:
         if isinstance(par_dict[key], str):
             par_dict[key] = par_dict[key].replace("$par_folder", str(par_folder))
-    integrate(work_folder=work_folder, **par_dict)
+    integrate(input_folder=input_folder, **par_dict)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #<issue number>
#373  and #372 

## Summary of the changes
Integration software (currently Eval and CrysalisPro) now have a common input_folder parameter of dtype "QCrBox.input_folder" making them identifiable available commands for user provided zip files


## How was it tested?
Running through the jupyter notebooks

## Additional considerations / follow-up work needed


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x ] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- ~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
- ~~- [ ] I added automated tests for my changes~~
- ~~- [ ] I updated any relevant documentation~~
- ~~- [ ] I created separate GitHub issues for any follow-up work needed~~
