### PR TITLE
Fix pre-build script detection

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -13,8 +13,8 @@ QCRBOX_SHARED_FILES_DIR_HOST_PATH=./shared_files/
 # By default, QCRBOX is only accessible on the same host, which makes
 # local development more secure. In order to access QCRBOX remotely,
 # the bind address should be set to "0.0.0.0".
-QCRBOX_BIND_ADDRESS="127.0.0.1"
-#QCRBOX_BIND_ADDRESS="0.0.0.0"
+#QCRBOX_BIND_ADDRESS="127.0.0.1"
+QCRBOX_BIND_ADDRESS="0.0.0.0"
 
 QCRBOX__REVERSE_PROXY__PORT=80
 QCRBOX__REVERSE_PROXY__WEBUI_PORT=8080

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Fixed an error when running `qcb build`. ([#335](https://github.com/QCrBox/QCrBox/issues/335))
 - Fixed formatting checks in CI runs. ([#370](https://github.com/QCrBox/QCrBox/issues/370))
 - Fixed missing dependency, leading to startup errors. ([#368](https://github.com/QCrBox/QCrBox/issues/368))
+- Fixed a bug that prevented pre-build scripts from being run if the build is invoked from a subdirectory. ([#385](https://github.com/QCrBox/QCrBox/issues/385))
 
 ### Development
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,10 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Fixed missing dependency, leading to startup errors. ([#368](https://github.com/QCrBox/QCrBox/issues/368))
 - Fixed a bug that prevented pre-build scripts from being run if the build is invoked from a subdirectory. ([#385](https://github.com/QCrBox/QCrBox/issues/385))
 
+### Other changes
+
+- By default, containers now listen on all interfaces rather than just localhost.
+
 ### Development
 
 - Added dummy GUI application for testing of interactive sessions. ([#364](https://github.com/QCrBox/QCrBox/issues/364))

--- a/pyqcrbox/pyqcrbox/cli/helpers/docker_project.py
+++ b/pyqcrbox/pyqcrbox/cli/helpers/docker_project.py
@@ -31,7 +31,7 @@ class DockerProject:
         return self.compose_file_config.services_excluding_base_images
 
     def get_build_context(self, service_name):
-        return self.compose_file_config.get_build_context(service_name)
+        return (self.repo_root / self.compose_file_config.get_build_context(service_name)).absolute()
 
     def get_direct_dependencies(self, service_name: str, include_build_deps: bool = False):
         return self.compose_file_config.get_direct_dependencies(service_name, include_build_deps=include_build_deps)


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #385 


## Summary of the changes

The docker build context (which is searched for the presence of any pre-build scripts) was previously returned as a path relative to the root of the repository. This made the detection fail when the build was invoked from a subdirectory. It is now passed as an absolute path.

As an unrelated change, I also changed the default value of `QCRBOX_BIND_ADDRESS` from `127.0.0.1` to `0.0.0.0`. This ensures that when running `qcb up`, the docker containers will listen on all IP addresses and are thus accessible remotely (for example, when deploying to a cloud VM).

## How was it tested?

By running `qcb build crystal-explorer` from a subdirectory and checking that the build now succeeds.


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [X] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [X] I added a changelog entry in `docs/CHANGELOG.md`
- ~~[ ] I added automated tests for my changes~~
- ~~[ ] I updated any relevant documentation~~
- ~~[ ] I created separate GitHub issues for any follow-up work needed~~
