### PR TITLE
Add deployment script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 ### New Features
 
 - Implemented persistence of imported data files and associated metadata. ([#352](https://github.com/QCrBox/QCrBox/issues/352))
+- Added deployment script (`scripts/deploy.sh`). ([#381](https://github.com/QCrBox/QCrBox/issues/381))
 
 ### Enhancements
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,51 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+export QCRBOX_REPO=${QCRBOX_REPO:-"$(git rev-parse --show-toplevel)"}
+export QCRBOX_BRANCH=${QCRBX_BRANCH:-"dev"}
+export QCRBOX_COMPONENTS=${QCRBOX_COMPONENTS:-"olex2 crystal-explorer"}
+
+
+prompt_for_confirmation() {
+    local answer
+    read -p "Proceed? ([Y]es/[n]o): " answer
+    case ${answer} in
+        y|Y|"" )
+            echo "Proceeding with deployment"
+            ;;
+        n|N|*)
+            echo "Exiting deployment."
+            exit 0
+            ;;
+    esac
+}
+
+
+print_planned_actions() {
+    local qcrbox_repo=$1
+    local branch=$2
+    local components=$3
+
+    echo "- Path to QCrBox repo (set QCRBOX_REPO to override):  ${qcrbox_repo}"
+    echo "- Branch to be deployed (set QCRBOX_BRANCH to override):  ${branch}"
+    echo "- Components to be started (set QCRBOX_COMPONENTS to override):  ${components}"
+
+    echo
+}
+
+
+main() {
+    print_planned_actions "${QCRBOX_REPO}" "${QCRBOX_BRANCH}" "${QCRBOX_COMPONENTS}"
+    prompt_for_confirmation
+
+    cd $QCRBOX_REPO
+    devbox run qcb down
+    devbox run git checkout $QCRBOX_BRANCH
+    devbox run git pull
+    devbox run qcb build $QCRBOX_COMPONENTS
+    devbox run qcb up --no-build $QCRBOX_COMPONENTS
+
+    echo "Deployment successful"
+}
+main

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 export QCRBOX_REPO=${QCRBOX_REPO:-"$(git rev-parse --show-toplevel)"}
-export QCRBOX_BRANCH=${QCRBX_BRANCH:-"dev"}
+export QCRBOX_BRANCH=${QCRBOX_BRANCH:-"dev"}
 export QCRBOX_COMPONENTS=${QCRBOX_COMPONENTS:-"olex2 crystal-explorer"}
 
 


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #381 


## Summary of the changes

Added the script `scripts/deploy.sh` which can be run to update an existing deployment. It will display the branch (default: `dev`) and QCrBox components (default: `olex2`, `crystal-explorer`) to be deployed and ask for confirmation before proceeding. The default values can be changed via the environment variables `QCRBOX_BRANCH` and `QCRBOX_COMPONENTS` (these are also displayed in the confirmation message).


## How was it tested?

By running `./scripts/deploy.sh` and checking that the expected containers are successfully built and started.


## Additional considerations / follow-up work needed

Although not strictly necessary, it could be useful to integrate this into the `qcb` command line utility and include a few more error checks.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [X] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [X] I added a changelog entry in `docs/CHANGELOG.md`
- ~~[ ] I added automated tests for my changes~~
- ~~[ ] I updated any relevant documentation~~
- ~~[ ] I created separate GitHub issues for any follow-up work needed~~
