### PR TITLE
Fix deployment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,8 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Fixed formatting checks in CI runs. ([#370](https://github.com/QCrBox/QCrBox/issues/370))
 - Fixed missing dependency, leading to startup errors. ([#368](https://github.com/QCrBox/QCrBox/issues/368))
 - Fixed a bug that prevented pre-build scripts from being run if the build is invoked from a subdirectory. ([#385](https://github.com/QCrBox/QCrBox/issues/385))
+- Fixed an issue that prevented the deployment script from running. ([#393](https://github.com/QCrBox/QCrBox/issues/393))
+- Fixed an issue that prevented the Olex2 docker image from being built. ([#394](https://github.com/QCrBox/QCrBox/issues/394))
 
 ### Other changes
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,6 +22,16 @@ prompt_for_confirmation() {
 }
 
 
+abort_if_not_running_within_devbox_shell() {
+    local devbox_shell_enabled=${DEVBOX_SHELL_ENABLED:-}
+
+    if [ "${devbox_shell_enabled}" = "" ]; then
+        echo "This script must be run from within a devbox shell."
+        echo "Please run 'devbox shell' and then execute it again."
+        exit 1
+    fi
+}
+
 print_planned_actions() {
     local qcrbox_repo=$1
     local branch=$2
@@ -36,6 +46,7 @@ print_planned_actions() {
 
 
 main() {
+    abort_if_not_running_within_devbox_shell
     print_planned_actions "${QCRBOX_REPO}" "${QCRBOX_BRANCH}" "${QCRBOX_COMPONENTS}"
     prompt_for_confirmation
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,6 +45,12 @@ print_planned_actions() {
 }
 
 
+remove_docker_volumes() {
+    echo "Removing Docker volumes for NATS storage and QCrBox server db"
+    docker volume rm -f qcrbox_qcrbox-nats-storage qcrbox_qcrbox-registry-db
+}
+
+
 main() {
     abort_if_not_running_within_devbox_shell
     print_planned_actions "${QCRBOX_REPO}" "${QCRBOX_BRANCH}" "${QCRBOX_COMPONENTS}"
@@ -52,6 +58,7 @@ main() {
 
     cd $QCRBOX_REPO
     qcb down
+    remove_docker_volumes
     git checkout $QCRBOX_BRANCH
     git pull
     qcb build $QCRBOX_COMPONENTS

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -51,11 +51,11 @@ main() {
     prompt_for_confirmation
 
     cd $QCRBOX_REPO
-    devbox run qcb down
-    devbox run git checkout $QCRBOX_BRANCH
-    devbox run git pull
-    devbox run qcb build $QCRBOX_COMPONENTS
-    devbox run qcb up --no-build $QCRBOX_COMPONENTS
+    qcb down
+    git checkout $QCRBOX_BRANCH
+    git pull
+    qcb build $QCRBOX_COMPONENTS
+    qcb up --no-build $QCRBOX_COMPONENTS
 
     echo "Deployment successful"
 }

--- a/services/applications/olex2_linux/Dockerfile
+++ b/services/applications/olex2_linux/Dockerfile
@@ -28,7 +28,7 @@ COPY --chown=${QCRBOX_USER}:${QCRBOX_GROUP} ./olex2_files/olex2-linux64_hl.zip /
 USER ${QCRBOX_USER}
 
 RUN cd /opt &&  \
-    unzip olex2/olex2-linux64_hl.zip && \
+    unzip -o olex2/olex2-linux64_hl.zip && \
     rm olex2/olex2-linux64_hl.zip && \
     chmod +x olex2/olex2c-linux64 && \
     chmod +x olex2/startc


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #393 
- Fixes #394 

## Summary of the changes

- Made the deployment script more robust by avoiding the use of `devbox run`.
- Modified the Dockerfile for Olex2 to prevent the `unzip` command which extracts the olex zip file from breaking the build.


## How was it tested?

By running the deployment script on a VM.


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [X] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [X] I added a changelog entry in `docs/CHANGELOG.md`
- ~~[ ] I added automated tests for my changes~~
- ~~[ ] I updated any relevant documentation~~
- ~~[ ] I created separate GitHub issues for any follow-up work needed~~
