### PR TITLE
Fixes 441 - remove deprecated and faiing tests

### DIFF
--- a/.github/workflows/qcrbox-ci.yml
+++ b/.github/workflows/qcrbox-ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - dev
       - main
-      - 441-remove-old-tests
   pull_request:
     branches:
       - dev

--- a/.github/workflows/qcrbox-ci.yml
+++ b/.github/workflows/qcrbox-ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - dev
       - main
+      - 441-remove-old-tests
   pull_request:
     branches:
       - dev

--- a/.github/workflows/qcrbox-ci.yml
+++ b/.github/workflows/qcrbox-ci.yml
@@ -80,23 +80,3 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           args: format --diff --config pyqcrbox/pyproject.toml
-
-  pyqcrbox-tests:
-    runs-on: ubuntu-latest
-    steps:
-      # Checks out the  repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          cache: 'pip' # caching pip dependencies
-
-      - name: Install dependencies
-        run: |
-          pip install ./pyqcrbox[all]
-
-      - name: Run the tests
-        run: |
-          cd pyqcrbox
-          pytest -svx --cov-config=.coveragerc ./tests


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #441 

## Summary of the changes

As per discussion on 19th June technical meeting, removes the failing unit tests run by the repository workflow (although the workflow as a whole still fails due to other failing workflow parts).

## How was it tested?

By adding the feature branch to list of branches that triggers the workflow in the workflow YAML file, committing and pushing the change. The tests part of the workflow did not run and was not reported in the GA log.