### PR TITLE
Hotfix for interactive session failing due to validation errors

### DIFF
--- a/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_file_manager.py
@@ -312,6 +312,15 @@ class DataFileManager(ABC):
 
     @eel_logging
     async def get_interactive_sessions(self) -> list[InteractiveSessionInfo]:
+        """Get metadata about all interactive sessions.
+
+        Returns
+        -------
+        list[InteractiveSessionInfo]
+            A list of InteractiveSessionInfo containing metadata about the interactive
+            sessions
+
+        """
         keys = await self._get_kv_keys("interactive_sessions")
         values = [await self.get_interactive_session_info(key) for key in keys]
 

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -60,6 +60,7 @@ class InteractiveSessionCalculation(BaseCalculation):
             If 'prepare_calc' or 'finalise_calc' are not instances of PythonCallableCalculation.
         FileNotFoundError
             If the output file from the 'finalise' command cannot be found during import.
+
         """
         if self.prepare_calc:
             assert isinstance(
@@ -85,7 +86,7 @@ class InteractiveSessionCalculation(BaseCalculation):
             await self.finalise_calc.wait_until_finished()
 
             output_file = self.finalise_calc.return_value
-            if output_file is None:
+            if not output_file:
                 logger.info("No output file from interactive session")
             else:
                 data_manager = await get_data_file_manager()
@@ -126,11 +127,15 @@ class InteractiveSessionCalculation(BaseCalculation):
         if self.run_calc.status == CalculationStatusEnum.RUNNING:
             await self.run_calc.terminate()
         self.run_calc.calc_finished_event.set()
+        logger.debug("Set run_calc.calc_finished_event")
 
         # When the run calc is finished, this flag is used to communicate with the interactive
         # session wait_until_finished() that the finalise command can be run
         self.calc_finished_event.set()
+        logger.debug("Set calc_finished_event")
 
         # Keep waiting until the finalise calculation has finished and the output has been added to
         # the data store
+        logger.debug("Waiting for session_closed_event")
         await self.session_closed_event.wait()
+        logger.debug("Closed interactive session")

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -89,8 +89,8 @@ class QCrBoxClient(QCrBoxServerClientBase):
         status_details = CalculationStatusDetails(
             calculation_id=msg.calculation_id,
             status=CalculationStatusEnum.FAILED,
-            stdout=None,
-            stderr=None,
+            stdout="",
+            stderr="",
             extra_info={
                 "error_msg": f"Discarded calculation {msg.calculation_id!r} due to client status {self.status.status}",
             },
@@ -129,8 +129,8 @@ class QCrBoxClient(QCrBoxServerClientBase):
             status_details = CalculationStatusDetails(
                 calculation_id=msg.calculation_id,
                 status=CalculationStatusEnum.FAILED,
-                stdout=None,
-                stderr=None,
+                stdout="",
+                stderr="",
                 extra_info={"error_msg": error_msg},
             )
             await update_calculation_status_in_nats_kv(status_details)
@@ -176,11 +176,14 @@ class QCrBoxClient(QCrBoxServerClientBase):
             session_status = CalculationStatusEnum.FAILED
             output_dataset_id = None
 
-        return msg_specs.CloseInteractiveSessionResponseNATS(
+        msg = msg_specs.CloseInteractiveSessionResponseNATS(
             session_id=session_id,
             status=session_status,
             output_dataset_id=output_dataset_id,
         )
+        logger.debug(f"Close interactive session msg via nats: {msg}")
+
+        return msg
 
     @eel_logging
     async def get_calculation_status(

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
@@ -97,6 +97,8 @@ async def close_interactive_session(session_id: str) -> msg_specs.CloseInteracti
         f"{session_info.client_private_inbox}.interactive_session.close",
         rpc=True,
     )
+    logger.debug(f"{session_info.client_private_inbox}.interactive_session.close response: {response_json}")
+
     response = msg_specs.CloseInteractiveSessionResponseNATS(**response_json)
     return response
 

--- a/pyqcrbox/pyqcrbox/sql_models/calculation_status_event.py
+++ b/pyqcrbox/pyqcrbox/sql_models/calculation_status_event.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class CalculationStatusEnum(StrEnum):
@@ -16,6 +16,11 @@ class CalculationStatusEnum(StrEnum):
 class CalculationStatusDetails(BaseModel):
     calculation_id: str
     status: CalculationStatusEnum
-    stdout: str = ""
-    stderr: str = ""
+    stdout: str | None = ""
+    stderr: str | None = ""
     extra_info: dict = {}
+
+    @field_validator("stdout", "stderr", mode="before")
+    @classmethod
+    def none_to_empty_str(cls, v):
+        return "" if v is None else v


### PR DESCRIPTION
## This PR addresses the following issue(s)

N/A

## Summary of the changes

This fixes a Pydanatic validation error when updating the calculation database. Only happened after merging `qcrbox-rework` into `dev`. No idea why it didn't show up before, but suspect there was some sort of merge error which caused this.

## How was it tested?

- Robot tests API client
- Clicking through UI in QCrBox frontend

## Additional considerations / follow-up work needed

None
