### PR TITLE
Fix outdated and failing GA actions

### DIFF
--- a/.github/workflows/qcrbox-ci.yml
+++ b/.github/workflows/qcrbox-ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - dev
       - main
-      - 450-deploy-ghpages-fail
   pull_request:
     branches:
       - dev

--- a/.github/workflows/qcrbox-ci.yml
+++ b/.github/workflows/qcrbox-ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - dev
       - main
+      - 450-deploy-ghpages-fail
   pull_request:
     branches:
       - dev
@@ -39,7 +40,7 @@ jobs:
 #        run: cd .build/docs_site/ && tar -czvf ../qcrbox_docs.tar.gz .
 #
       - name: Upload docs build output as GitHub pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: .build/docs_site/
 
@@ -60,11 +61,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action
+        uses: actions/deploy-pages@v4 # or the latest "vX.X.X" version tag for this action
 
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #450

## Summary of the changes

Updated versions of some github actions which were causing the build-docs and deploy-docs build steps to fail.

## How was it tested?

It can only be tested on the dev or main branches, so will be tested on dev.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x ] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
