### PR TITLE
Add Glossary page to technical reference documentation

### DIFF
--- a/docs/technical_reference/glossary.md
+++ b/docs/technical_reference/glossary.md
@@ -2,21 +2,21 @@
 
 The following table lists key terms used throughout QCrBox.
 
-| Term                      | Description |
-|---------------------------|-------------|
-| API Client                | A Python client responsible for sending requests to and managing responses from the QCrBox registry. |
-| Application               | A software application provided by QCrBox, such as Crystal Explorer or Olex2. |
-| Application Container     | A (Docker) container in which an application runs, providing also a VNC server for interactive sessions. |
-| Application Specification | A YAML file containing metadata that configures an Application Container to run a specific application. |
+| Term                      | Description                                                                                                                                                   |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| API Client                | A Python client responsible for sending requests to and managing responses from the QCrBox registry.                                                          |
+| Application               | A software application provided by QCrBox, such as Crystal Explorer or Olex2.                                                                                 |
+| Application Container     | A (Docker) container in which an application runs, providing also a VNC server for interactive sessions.                                                      |
+| Application Specification | A YAML file containing metadata that configures an Application Container to run a specific application.                                                       |
 | Client                    | An instance of `QCrBoxClient` that manages the execution and management of an Application and command requests, by the user, within an Application Container. |
-| Calculation               | A representation of a running or completed job. |
-| Command                   | A specific functionality or operation provided by an Application available to users. |
-| Command Specification     | A section within the Application Specification YAML file that defines the commands an Application exposes to QCrBox. |
-| Dataset                   | A collection of data files grouped together. |
-| Data File                 | An individual file, typically a .CIF file. |
-| Data and Object Store     | The storage system for persistent data, such as datasets, data files, and metadata about applications and commands. Currently, this is provided by NATS. |
-| Interactive Session       | A command that launches a GUI interface for user interaction. |
-| Non-interactive Session   | A command that runs without requiring user interaction. |
-| Registry                  | The central registry database and message bus that registers and launches applications and their commands in response to user requests. |
-| Server                    | An instance of `QCrBoxServer` responsible for managing the registry. |
-| Workflow                  | A sequence of commands executed in a specific order with designated datasets. |
+| Calculation               | A representation of a running or completed job.                                                                                                               |
+| Command                   | A specific functionality or operation provided by an Application available to users.                                                                          |
+| Command Specification     | A section within the Application Specification YAML file that defines the commands an Application exposes to QCrBox.                                          |
+| Dataset                   | A collection of data files grouped together.                                                                                                                  |
+| Data File                 | An individual file, typically a .CIF file.                                                                                                                    |
+| Data and Object Store     | The storage system for persistent data, such as datasets, data files, and metadata about applications and commands. Currently, this is provided by NATS.      |
+| Interactive Session       | A command that launches a GUI interface for user interaction.                                                                                                 |
+| Non-interactive Session   | A command that runs without requiring user interaction.                                                                                                       |
+| Registry                  | The central registry database and message bus that registers and launches applications and their commands in response to user requests.                       |
+| Server                    | An instance of `QCrBoxServer` responsible for managing the registry.                                                                                          |
+| Workflow                  | A sequence of commands executed in a specific order with designated datasets.                                                                                 |

--- a/docs/technical_reference/glossary.md
+++ b/docs/technical_reference/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+
+| Term | Description |
+| ---- | ----------- |
+| | |

--- a/docs/technical_reference/glossary.md
+++ b/docs/technical_reference/glossary.md
@@ -1,5 +1,22 @@
 # Glossary
 
-| Term | Description |
-| ---- | ----------- |
-| | |
+The following table lists key terms used throughout QCrBox.
+
+| Term                      | Description |
+|---------------------------|-------------|
+| API Client                | A Python client responsible for sending requests to and managing responses from the QCrBox registry. |
+| Application               | A software application provided by QCrBox, such as Crystal Explorer or Olex2. |
+| Application Container     | A (Docker) container in which an application runs, providing also a VNC server for interactive sessions. |
+| Application Specification | A YAML file containing metadata that configures an Application Container to run a specific application. |
+| Client                    | An instance of `QCrBoxClient` that manages the execution and management of an Application and command requests, by the user, within an Application Container. |
+| Calculation               | A representation of a running or completed job. |
+| Command                   | A specific functionality or operation provided by an Application available to users. |
+| Command Specification     | A section within the Application Specification YAML file that defines the commands an Application exposes to QCrBox. |
+| Dataset                   | A collection of data files grouped together. |
+| Data File                 | An individual file, typically a .CIF file. |
+| Data and Object Store     | The storage system for persistent data, such as datasets, data files, and metadata about applications and commands. Currently, this is provided by NATS. |
+| Interactive Session       | A command that launches a GUI interface for user interaction. |
+| Non-interactive Session   | A command that runs without requiring user interaction. |
+| Registry                  | The central registry database and message bus that registers and launches applications and their commands in response to user requests. |
+| Server                    | An instance of `QCrBoxServer` responsible for managing the registry. |
+| Workflow                  | A sequence of commands executed in a specific order with designated datasets. |


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #417

## Summary of the changes

Adds a new page to the technical reference documentation which contains a table of terms, including their definition.

## How was it tested?

N/A

## Additional considerations / follow-up work needed

This is just the first iteration of the glossary. We will slowly add to it, including for the front-end.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- ~~[ ] I added a changelog entry in `docs/CHANGELOG.md`~~
- ~~[ ] I added automated tests for my changes~~
- ~~[ ] I updated any relevant documentation~~
- ~~[ ] I created separate GitHub issues for any follow-up work needed~~

- ~~- [ ] Example of a crossed-out item that does not apply to this PR~~
