### PR TITLE
Provide feedback for errors in interactive session

### DIFF
--- a/pyqcrbox/pyqcrbox/msg_specs/msg_types/client_side/get_calculation_status.py
+++ b/pyqcrbox/pyqcrbox/msg_specs/msg_types/client_side/get_calculation_status.py
@@ -25,3 +25,4 @@ class CloseInteractiveSessionResponseNATS(QCrBoxPydanticBaseModel):
     session_id: str
     status: str
     output_dataset_id: str | None
+    error_msg: str | None = None

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/base_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/base_calculation.py
@@ -21,6 +21,7 @@ class BaseCalculation(metaclass=ABCMeta):
     def __init__(self, *, calculation_id: str, calc_finished_event: anyio.Event) -> None:
         self.calculation_id = calculation_id
         self.calc_finished_event = calc_finished_event
+        self.exception = None
 
     def __repr__(self):
         """Return a string representation of the calculation instance.

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command_calculation.py
@@ -36,10 +36,15 @@ class CLICmdCalculation(BaseCalculation):
 
     async def wait_until_finished(self):
         """Wait until the calculation is finished."""
-        # await self.proc.wait()
-        await self.calc_finished_event.wait()
+        await self.proc.wait()
         if self.status == CalculationStatusEnum.FAILED:
-            logger.error(f"CLI Command failed:\nStdout:\n\n{await self.stdout}\n\nStderr:\n\n{await self.stderr}")
+            logger.error(
+                f"CLI Command failed:\nStdout:\n\n{await self.stdout}\n\nStderr:\n\n{await self.stderr}",
+            )
+            self.exception = RuntimeError(
+                f"CLI command failed with return code {self.proc.returncode}: {await self.stderr}"
+            )
+        self.calc_finished_event.set()
 
     @property
     def status(self) -> CalculationStatusEnum:

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/error.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/error.py
@@ -1,0 +1,32 @@
+import multiprocessing
+import tkinter
+import tkinter.messagebox
+
+
+def error_dialog_box(message: str) -> multiprocessing.Process:
+    """Display an error dialog with the given message using tkinter messagebox.
+
+    The dialog box is launched in a separate process.
+
+    Parameters
+    ----------
+    message : str
+        The error message to display in the dialog box.
+
+    Returns
+    -------
+    multiprocessing.Process
+        The process containing the dialog box.
+
+    """
+
+    def _error_box():
+        window = tkinter.Tk()
+        window.withdraw()
+        tkinter.messagebox.showinfo("Error!", message)
+        window.destroy()
+
+    process = multiprocessing.Process(target=_error_box)
+    process.start()
+
+    return process

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/error.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/error.py
@@ -3,15 +3,21 @@ import tkinter
 import tkinter.messagebox
 
 
-class PrepareCommandFailure(Exception):
+class CommandFailure(Exception):
+    def __init__(self, message: str, original_exception: Exception | None = None) -> None:
+        super().__init__(message)
+        self.original_exception = original_exception
+
+
+class PrepareCommandFailure(CommandFailure):
     pass
 
 
-class RunCommandFailure(Exception):
+class RunCommandFailure(CommandFailure):
     pass
 
 
-class FinaliseCommandFailure(Exception):
+class FinaliseCommandFailure(CommandFailure):
     pass
 
 

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/error.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/error.py
@@ -3,6 +3,18 @@ import tkinter
 import tkinter.messagebox
 
 
+class PrepareCommandFailure(Exception):
+    pass
+
+
+class RunCommandFailure(Exception):
+    pass
+
+
+class FinaliseCommandFailure(Exception):
+    pass
+
+
 def error_dialog_box(message: str) -> multiprocessing.Process:
     """Display an error dialog with the given message using tkinter messagebox.
 

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/executable_command.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/executable_command.py
@@ -1,9 +1,8 @@
 from typing import TYPE_CHECKING
 
-from click import BaseCommand
-
 from pyqcrbox.sql_models.command_spec import ImplementedAs
 
+from .base_command import BaseCommand
 from .cli_command import CLICommand
 from .interactive_session import InteractiveSession
 from .python_callable import PythonCallable

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,7 @@ from pyqcrbox import helpers, logger
 from pyqcrbox.registry.client.executable_command import BaseCommand
 from pyqcrbox.registry.client.executable_command.python_callable import PythonCallable
 from pyqcrbox.sql_models import InteractiveSessionSpec
+from pyqcrbox.sql_models.calculation_status_event import CalculationStatusEnum
 
 from .interactive_session_calculation import InteractiveSessionCalculation
 
@@ -135,6 +137,15 @@ class InteractiveSession(BaseCommand):
                 )
                 await interactive_session_calc.prepare_calc.wait_until_finished()
                 logger.debug("Prepare command has finished executing")
+                if interactive_session_calc.prepare_calc.status == CalculationStatusEnum.FAILED:
+                    logger.error(
+                        f"Exception raised by prepare_cmd: {interactive_session_calc.prepare_calc.return_value}"
+                    )
+                    subprocess.run(
+                        ["/bin/bash", "xmessage", "Prepare command failed!"],
+                        env={**os.environ, "DISPLAY": ":0"},
+                    )
+                    return
 
             logger.debug(f"Executing run command in background and waiting for it to finish: {run_cmd}")
             interactive_session_calc.run_calc = await run_cmd.execute_in_background(

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +7,7 @@ import anyio
 
 from pyqcrbox import helpers, logger
 from pyqcrbox.registry.client.executable_command import BaseCommand
+from pyqcrbox.registry.client.executable_command.error import error_dialog_box
 from pyqcrbox.registry.client.executable_command.python_callable import PythonCallable
 from pyqcrbox.sql_models import InteractiveSessionSpec
 from pyqcrbox.sql_models.calculation_status_event import CalculationStatusEnum
@@ -68,7 +68,7 @@ class InteractiveSession(BaseCommand):
         _stdin_stream: asyncio.StreamWriter | None = None,
         _stdout_stream: asyncio.StreamReader | None = None,
         _stderr_stream: asyncio.StreamReader | None = None,
-        _cwd: str | Path = None,
+        _cwd: str | Path | None = None,
         **kwargs,
     ) -> InteractiveSessionCalculation:
         """Launch an interactive session calculation asynchronously.
@@ -109,7 +109,8 @@ class InteractiveSession(BaseCommand):
         interactive_session_calc = InteractiveSessionCalculation(
             calculation_id=_calculation_id,
             calc_finished_event=calc_finished_event,
-            prepare_calc=None,  # the following three will be set after the task begins
+            async_task=None,  # the following will be set after the task begins
+            prepare_calc=None,
             run_calc=None,
             finalise_calc=None,
         )
@@ -136,16 +137,14 @@ class InteractiveSession(BaseCommand):
                     **param_values,
                 )
                 await interactive_session_calc.prepare_calc.wait_until_finished()
-                logger.debug("Prepare command has finished executing")
                 if interactive_session_calc.prepare_calc.status == CalculationStatusEnum.FAILED:
+                    raised_exception = interactive_session_calc.prepare_calc.exception
                     logger.error(
-                        f"Exception raised by prepare_cmd: {interactive_session_calc.prepare_calc.return_value}"
+                        f"Exception raised by prepare_cmd: {raised_exception}",
                     )
-                    subprocess.run(
-                        ["/bin/bash", "xmessage", "Prepare command failed!"],
-                        env={**os.environ, "DISPLAY": ":0"},
-                    )
-                    return
+                    error_dialog_box(f"An error occurred in the prepare command: {raised_exception}")
+                    raise RuntimeError("Prepare command failed") from interactive_session_calc.prepare_calc.exception
+                logger.debug("Prepare command has finished executing")
 
             logger.debug(f"Executing run command in background and waiting for it to finish: {run_cmd}")
             interactive_session_calc.run_calc = await run_cmd.execute_in_background(
@@ -166,6 +165,6 @@ class InteractiveSession(BaseCommand):
                     **param_values,
                 )
 
-        asyncio.create_task(session_tasks())
+        interactive_session_calc.background_task = asyncio.create_task(session_tasks())
 
         return interactive_session_calc

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -10,7 +10,6 @@ from pyqcrbox.registry.client.executable_command import BaseCommand
 from pyqcrbox.registry.client.executable_command.error import error_dialog_box
 from pyqcrbox.registry.client.executable_command.python_callable import PythonCallable
 from pyqcrbox.sql_models import InteractiveSessionSpec
-from pyqcrbox.sql_models.calculation_status_event import CalculationStatusEnum
 
 from .interactive_session_calculation import InteractiveSessionCalculation
 
@@ -127,6 +126,7 @@ class InteractiveSession(BaseCommand):
         async def session_tasks():
             nonlocal run_cmd, prepare_cmd, finalise_cmd
 
+            # Run prepare command, wait for it to finish, and handle errors
             if prepare_cmd:
                 if not isinstance(prepare_cmd, PythonCallable):
                     raise TypeError("Only `PythonCallable` is supported for 'prepare_cmd'")
@@ -137,15 +137,18 @@ class InteractiveSession(BaseCommand):
                     **param_values,
                 )
                 await interactive_session_calc.prepare_calc.wait_until_finished()
-                if interactive_session_calc.prepare_calc.status == CalculationStatusEnum.FAILED:
+                if interactive_session_calc.prepare_calc.exception:
+                    calc_status = interactive_session_calc.prepare_calc.status
                     raised_exception = interactive_session_calc.prepare_calc.exception
                     logger.error(
-                        f"Exception raised by prepare_cmd: {raised_exception}",
+                        f"Exception raised by prepare_cmd (calc status {calc_status}): {raised_exception}",
                     )
                     error_dialog_box(f"An error occurred in the prepare command: {raised_exception}")
                     raise RuntimeError("Prepare command failed") from interactive_session_calc.prepare_calc.exception
                 logger.debug("Prepare command has finished executing")
 
+            # Run the main interactive command (run command), wait for it to finish
+            # and handle errors
             logger.debug(f"Executing run command in background and waiting for it to finish: {run_cmd}")
             interactive_session_calc.run_calc = await run_cmd.execute_in_background(
                 _calculation_id=helpers.generate_calculation_id(),
@@ -153,8 +156,19 @@ class InteractiveSession(BaseCommand):
                 **param_values,
             )
             await interactive_session_calc.run_calc.wait_until_finished()
+            if interactive_session_calc.run_calc.exception:
+                calc_status = interactive_session_calc.run_calc.status
+                raised_exception = interactive_session_calc.run_calc.exception
+                logger.error(
+                    f"Exception raised by run_cmd (calc status {calc_status}): {raised_exception}",
+                )
+                error_dialog_box(f"An error occurred in the run command: {raised_exception}")
+                await interactive_session_calc.run_calc.terminate()
+                raise RuntimeError("Run command failed") from interactive_session_calc.run_calc.exception
             logger.debug("Run command has finished executing")
 
+            # Launch finalise command, but don't wait for it to finish. We wait for this
+            # to finish in the interactive session calculation
             if finalise_cmd:
                 if not isinstance(finalise_cmd, PythonCallable):
                     raise TypeError("Only `PythonCallable` is supported for 'finalise_cmd'")

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -7,7 +7,7 @@ import anyio
 
 from pyqcrbox import helpers, logger
 from pyqcrbox.registry.client.executable_command import BaseCommand
-from pyqcrbox.registry.client.executable_command.error import error_dialog_box
+from pyqcrbox.registry.client.executable_command.error import PrepareCommandFailure, RunCommandFailure, error_dialog_box
 from pyqcrbox.registry.client.executable_command.python_callable import PythonCallable
 from pyqcrbox.sql_models import InteractiveSessionSpec
 
@@ -144,7 +144,9 @@ class InteractiveSession(BaseCommand):
                         f"Exception raised by prepare_cmd (calc status {calc_status}): {raised_exception}",
                     )
                     error_dialog_box(f"An error occurred in the prepare command: {raised_exception}")
-                    raise RuntimeError("Prepare command failed") from interactive_session_calc.prepare_calc.exception
+                    raise PrepareCommandFailure(
+                        "Prepare command failed"
+                    ) from interactive_session_calc.prepare_calc.exception
                 logger.debug("Prepare command has finished executing")
 
             # Run the main interactive command (run command), wait for it to finish
@@ -163,7 +165,7 @@ class InteractiveSession(BaseCommand):
                     f"Exception raised by run_cmd (calc status {calc_status}): {raised_exception}",
                 )
                 error_dialog_box(f"An error occurred in the run command: {raised_exception}")
-                raise RuntimeError("Run command failed") from interactive_session_calc.run_calc.exception
+                raise RunCommandFailure("Run command failed") from interactive_session_calc.run_calc.exception
             logger.debug("Run command has finished executing")
 
             # Launch finalise command, but don't wait for it to finish. We wait for this

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -163,7 +163,6 @@ class InteractiveSession(BaseCommand):
                     f"Exception raised by run_cmd (calc status {calc_status}): {raised_exception}",
                 )
                 error_dialog_box(f"An error occurred in the run command: {raised_exception}")
-                await interactive_session_calc.run_calc.terminate()
                 raise RuntimeError("Run command failed") from interactive_session_calc.run_calc.exception
             logger.debug("Run command has finished executing")
 

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -145,7 +145,7 @@ class InteractiveSession(BaseCommand):
                     )
                     error_dialog_box(f"An error occurred in the prepare command: {raised_exception}")
                     raise PrepareCommandFailure(
-                        "Prepare command failed"
+                        "Prepare command failed", interactive_session_calc.prepare_calc.exception
                     ) from interactive_session_calc.prepare_calc.exception
                 logger.debug("Prepare command has finished executing")
 
@@ -165,7 +165,9 @@ class InteractiveSession(BaseCommand):
                     f"Exception raised by run_cmd (calc status {calc_status}): {raised_exception}",
                 )
                 error_dialog_box(f"An error occurred in the run command: {raised_exception}")
-                raise RunCommandFailure("Run command failed") from interactive_session_calc.run_calc.exception
+                raise RunCommandFailure(
+                    "Run command failed", interactive_session_calc.run_calc.exception
+                ) from interactive_session_calc.run_calc.exception
             logger.debug("Run command has finished executing")
 
             # Launch finalise command, but don't wait for it to finish. We wait for this

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -91,10 +91,12 @@ class InteractiveSessionCalculation(BaseCalculation):
                 calc_status = self.finalise_calc.status
                 logger.error(f"Exception raised by finalise_cmd ({calc_status}): {self.finalise_calc.exception!r}")
                 error_dialog_box(f"An error occurred in the finalise command: {self.finalise_calc.exception}")
-                self.exception = FinaliseCommandFailure("Finalise command failed")
+                self.exception = FinaliseCommandFailure("Finalise command failed", self.finalise_calc.exception)
                 raise self.exception from self.finalise_calc.exception
             logger.debug("Finalise command has finished")
 
+            # The above will only run if the finalise calc finished successfully, e.g.
+            # we didn't raise an exception in the above step
             output_file = self.finalise_calc.return_value
             if not output_file:
                 logger.info("No output file from interactive session")

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import anyio
 
 from pyqcrbox import logger
@@ -14,6 +16,7 @@ class InteractiveSessionCalculation(BaseCalculation):
         *,
         calculation_id: str,
         calc_finished_event: anyio.Event,
+        async_task: asyncio.Task,
         prepare_calc: BaseCalculation | None,
         run_calc: BaseCalculation,
         finalise_calc: BaseCalculation | None,
@@ -22,12 +25,10 @@ class InteractiveSessionCalculation(BaseCalculation):
         self.prepare_calc = prepare_calc
         self.run_calc = run_calc
         self.finalise_calc = finalise_calc
+        self.background_task = async_task
         self.is_closed = False
         self.output_dataset_id = None
         self.session_closed_event = anyio.Event()
-        logger.debug(
-            f"Created new InteractiveSessionCalculation: {self!r}",
-        )
 
     @property
     def status(self) -> CalculationStatusEnum:
@@ -63,6 +64,13 @@ class InteractiveSessionCalculation(BaseCalculation):
             If the output file from the 'finalise' command cannot be found during import.
 
         """
+        # await the background task so we can capture any exceptions which were raised
+        # in it and re-raise them to propagate them back up
+        try:
+            await self.background_task
+        except Exception:
+            raise
+
         # We have to wait for the "calc_finished" event to be set, which only can happen
         # when we try and close the interactive session
         logger.debug("Waiting for 'calc_finished' event to be set upon calculation termination")

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -69,6 +69,8 @@ class InteractiveSessionCalculation(BaseCalculation):
         try:
             await self.background_task
         except Exception:
+            self.is_closed = True
+            self.session_closed_event.set()
             raise
 
         # We have to wait for the "calc_finished" event to be set, which only can happen
@@ -80,6 +82,7 @@ class InteractiveSessionCalculation(BaseCalculation):
             assert isinstance(self.finalise_calc, PythonCallableCalculation)
             logger.debug(f"Waiting for 'finalise' command to finish: {self.finalise_calc!r}")
             await self.finalise_calc.wait_until_finished()
+            logger.debug("Finalise command has finished")
 
             output_file = self.finalise_calc.return_value
             if not output_file:
@@ -96,6 +99,7 @@ class InteractiveSessionCalculation(BaseCalculation):
                     "The output from the interactive session has been placed into dataset %s", self.output_dataset_id
                 )
 
+        logger.debug("All commands have finished, waiting for session close")
         self.is_closed = True
         self.session_closed_event.set()
         logger.debug(f"InteractiveSessionCalculation: interactive session finished: {self}")
@@ -119,10 +123,10 @@ class InteractiveSessionCalculation(BaseCalculation):
         # event which *should* cause run_calc.wait_until_finished() to exit. If this flag isn't set, then
         # execution will hang
         if self.prepare_calc == CalculationStatusEnum.RUNNING:
-            logger.debug("Terminating prepare command")
+            logger.debug("Terminating prepare command in InteractiveSessionCalculation.terminate()")
             await self.prepare_calc.terminate()
         if self.run_calc.status == CalculationStatusEnum.RUNNING:
-            logger.debug("Terminating run command")
+            logger.debug("Terminating run command in InteractiveSessionCalculation.terminate()")
             await self.run_calc.terminate()
         self.run_calc.calc_finished_event.set()
 

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -3,6 +3,7 @@ import asyncio
 import anyio
 
 from pyqcrbox import logger
+from pyqcrbox.registry.client.executable_command.error import error_dialog_box
 from pyqcrbox.services import get_data_file_manager
 from pyqcrbox.sql_models import CalculationStatusEnum
 
@@ -69,8 +70,6 @@ class InteractiveSessionCalculation(BaseCalculation):
         try:
             await self.background_task
         except Exception:
-            self.is_closed = True
-            self.session_closed_event.set()
             raise
 
         # We have to wait for the "calc_finished" event to be set, which only can happen
@@ -82,6 +81,11 @@ class InteractiveSessionCalculation(BaseCalculation):
             assert isinstance(self.finalise_calc, PythonCallableCalculation)
             logger.debug(f"Waiting for 'finalise' command to finish: {self.finalise_calc!r}")
             await self.finalise_calc.wait_until_finished()
+            if self.finalise_calc.exception:
+                calc_status = self.finalise_calc.status
+                logger.error(f"Exception raised by finalise_cmd ({calc_status}): {self.finalise_calc.exception!r}")
+                error_dialog_box(f"An error occured in the finalise command: {self.finalise_calc.exception}")
+                raise RuntimeError("Finalise command failed") from self.finalise_calc.exception
             logger.debug("Finalise command has finished")
 
             output_file = self.finalise_calc.return_value

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -35,6 +35,8 @@ class InteractiveSessionCalculation(BaseCalculation):
     def status(self) -> CalculationStatusEnum:
         if not self.is_closed:
             return CalculationStatusEnum.RUNNING
+        elif self.exception:
+            return CalculationStatusEnum.FAILED
         else:
             return CalculationStatusEnum.SUCCESSFUL
 
@@ -69,11 +71,15 @@ class InteractiveSessionCalculation(BaseCalculation):
         # in it and re-raise them to propagate them back up
         try:
             await self.background_task
-        except Exception:
+        except Exception as exc:
+            self.exception = exc
             raise
 
         # We have to wait for the "calc_finished" event to be set, which only can happen
-        # when we try and close the interactive session
+        # when we try and close the interactive session. If we didn't wait then due to
+        # how this is set up, we would run the finalise command before we've finished
+        # interacting with the main run command. If we did everything in the foreground,
+        # then we wouldn't have to wait because the run_calc would be blocking.
         logger.debug("Waiting for 'calc_finished' event to be set upon calculation termination")
         await self.calc_finished_event.wait()
 
@@ -85,7 +91,8 @@ class InteractiveSessionCalculation(BaseCalculation):
                 calc_status = self.finalise_calc.status
                 logger.error(f"Exception raised by finalise_cmd ({calc_status}): {self.finalise_calc.exception!r}")
                 error_dialog_box(f"An error occurred in the finalise command: {self.finalise_calc.exception}")
-                raise FinaliseCommandFailure("Finalise command failed") from self.finalise_calc.exception
+                self.exception = FinaliseCommandFailure("Finalise command failed")
+                raise self.exception from self.finalise_calc.exception
             logger.debug("Finalise command has finished")
 
             output_file = self.finalise_calc.return_value

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -3,7 +3,7 @@ import asyncio
 import anyio
 
 from pyqcrbox import logger
-from pyqcrbox.registry.client.executable_command.error import error_dialog_box
+from pyqcrbox.registry.client.executable_command.error import FinaliseCommandFailure, error_dialog_box
 from pyqcrbox.services import get_data_file_manager
 from pyqcrbox.sql_models import CalculationStatusEnum
 
@@ -84,8 +84,8 @@ class InteractiveSessionCalculation(BaseCalculation):
             if self.finalise_calc.exception:
                 calc_status = self.finalise_calc.status
                 logger.error(f"Exception raised by finalise_cmd ({calc_status}): {self.finalise_calc.exception!r}")
-                error_dialog_box(f"An error occured in the finalise command: {self.finalise_calc.exception}")
-                raise RuntimeError("Finalise command failed") from self.finalise_calc.exception
+                error_dialog_box(f"An error occurred in the finalise command: {self.finalise_calc.exception}")
+                raise FinaliseCommandFailure("Finalise command failed") from self.finalise_calc.exception
             logger.debug("Finalise command has finished")
 
             output_file = self.finalise_calc.return_value

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
@@ -38,6 +38,7 @@ class PythonCallableCalculation(BaseCalculation):
         self._apply_result = result
         self.pool = pool
         self.return_value = None
+        self.exception = None
 
     async def wait_until_finished(self):
         """Wait until the calculation is finished."""
@@ -65,7 +66,7 @@ class PythonCallableCalculation(BaseCalculation):
                 try:
                     self._apply_result.get()
                 except Exception as exc:
-                    self.return_value = exc
+                    self.exception = exc
             logger.debug("Calculation finished, closing multiprocessing pool.")
             # When the result is ready, we can close the pool normally without
             # having to forcefully terminate the process and child processes

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
@@ -60,6 +60,12 @@ class PythonCallableCalculation(BaseCalculation):
                 calc_status = CalculationStatusEnum.SUCCESSFUL
             else:
                 calc_status = CalculationStatusEnum.FAILED
+                # This is less than ideal, but seems to be the only way to get the exception
+                # that was raised inside the pool.
+                try:
+                    self._apply_result.get()
+                except Exception as exc:
+                    self.return_value = exc
             logger.debug("Calculation finished, closing multiprocessing pool.")
             # When the result is ready, we can close the pool normally without
             # having to forcefully terminate the process and child processes

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
@@ -67,10 +67,12 @@ class PythonCallableCalculation(BaseCalculation):
                     self._apply_result.get()
                 except Exception as exc:
                     self.exception = exc
-            logger.debug("Calculation finished, closing multiprocessing pool.")
             # When the result is ready, we can close the pool normally without
             # having to forcefully terminate the process and child processes
             # by hand
+            logger.debug(
+                f"Calculation {self.calculation_id} finished with status {calc_status}, closing multiprocessing pool",
+            )
             self.pool.close()
             self.pool.join()
         else:

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -178,8 +178,9 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 raise RuntimeError("Command execution did not return a calculation object.")
             logger.debug(f"Executing command has returned calculation: {calc!r}")
         except Exception as exc:
+            logger.debug("cmd.execute_in_background() raised an exception")
             logger.error(
-                f"Command (either prepare or run) failed in background task with exception: {exc!r}",
+                f"Command failed in background task with exception: {exc!r}",
             )
             await self.handle_command_execution_exception(msg.calculation_id, exc)
             return
@@ -188,12 +189,13 @@ class QCrBoxClient(QCrBoxServerClientBase):
         self.calculations[msg.calculation_id] = calc
         await update_calculation_status_in_nats_kv(await calc.get_status_details())
 
-        # Wait until its finished and when finished, updated the details
+        # Wait until its finished and when finished, update the details
         try:
             await calc.wait_until_finished()
         except Exception as exc:
+            logger.debug("calc.wait_until_finished() raised an exception")
             logger.error(
-                f"Command (finalise) failed in background task with exception: {exc!r}",
+                f"Calculation failed in background task with exception: {exc!r}",
             )
             await self.handle_command_execution_exception(msg.calculation_id, exc)
             return
@@ -225,6 +227,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         await update_calculation_status_in_nats_kv(status_details)
         # Set client back to being idle, otherwise we wouldn't be able to request
         # new commands
+        logger.debug("Setting client status to idle in handle_command_execution_exception")
         self.status.set_idle()
 
     async def close_interactive_session(

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -9,6 +9,7 @@ from litestar import Litestar
 from pyqcrbox import helpers, logger, msg_specs, settings, sql_models
 from pyqcrbox.helpers import generate_private_routing_key
 from pyqcrbox.registry.client.executable_command.base_calculation import BaseCalculation
+from pyqcrbox.registry.client.executable_command.interactive_session_calculation import InteractiveSessionCalculation
 from pyqcrbox.registry.shared.calculation_status import update_calculation_status_in_nats_kv
 from pyqcrbox.services import get_data_file_manager
 from pyqcrbox.sql_models import CalculationStatusDetails, CalculationStatusEnum
@@ -197,6 +198,9 @@ class QCrBoxClient(QCrBoxServerClientBase):
             logger.error(
                 f"Calculation failed in background task with exception: {exc!r}",
             )
+            if isinstance(calc, InteractiveSessionCalculation):
+                calc.is_closed = True
+                calc.session_closed_event.set()
             await self.handle_command_execution_exception(msg.calculation_id, exc)
             return
 

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -41,7 +41,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         self.client_id = client_id
         self.private_routing_key = private_routing_key or generate_private_routing_key()
         self.work_root_dir = work_root_dir or self._create_work_root_dir()
-        self._calculations: list[BaseCommand] = []
+        self._calculations: list[BaseCalculation] = []
         self.status = ClientStatus(client_id, ClientStatusEnum.IDLE)
 
     def _create_work_root_dir(self) -> None:
@@ -153,7 +153,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
 
         if self.status.status != ClientStatusEnum.PENDING:
             logger.error(
-                f"Trying to execute a command when client is not PENDING. Current status: {self.status.status}"
+                f"Trying to execute a command when client is not PENDING (current status: {self.status.status})"
             )
             return
         self.status.set_busy()
@@ -162,7 +162,6 @@ class QCrBoxClient(QCrBoxServerClientBase):
 
         try:
             cmd = self.get_executable_command(msg.command_name)
-            logger.debug(f"InteractiveSession: Retrieved command {cmd.cmd_spec!r} ")
             # Parse each argument in `msg.arguments` as the correct parameter type
             # Steps:
             #   - get the command spec and look up parameter types for each argument
@@ -179,17 +178,10 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 raise RuntimeError("Command execution did not return a calculation object.")
             logger.debug(f"Executing command has returned calculation: {calc!r}")
         except Exception as exc:
-            error_msg = f"Command execution has failed: {exc!r}"
-            logger.error(error_msg)
-            status_details = CalculationStatusDetails(
-                calculation_id=msg.calculation_id,
-                status=CalculationStatusEnum.FAILED,
-                stdout="",
-                stderr="",
-                extra_info={"error_msg": error_msg},
+            logger.error(
+                f"Command (either prepare or run) failed in background task with exception: {exc!r}",
             )
-            await update_calculation_status_in_nats_kv(status_details)
-            self.status.set_idle()  # Should we set it back to idle? There could be a zombie process
+            await self.handle_command_execution_exception(msg.calculation_id, exc)
             return
 
         # Keep track of the calculation, which should still be running
@@ -197,8 +189,43 @@ class QCrBoxClient(QCrBoxServerClientBase):
         await update_calculation_status_in_nats_kv(await calc.get_status_details())
 
         # Wait until its finished and when finished, updated the details
-        await calc.wait_until_finished()
+        try:
+            await calc.wait_until_finished()
+        except Exception as exc:
+            logger.error(
+                f"Command (finalise) failed in background task with exception: {exc!r}",
+            )
+            await self.handle_command_execution_exception(msg.calculation_id, exc)
+            return
+
         await update_calculation_status_in_nats_kv(await calc.get_status_details())
+
+    async def handle_command_execution_exception(self, calculation_id: str, exception: Exception) -> None:
+        """Handle a command execution error.
+
+        This updates the calculation status to FAILED and sets the client back to
+        being idle. You therefore need to return from ASAP `handle_command_execution`
+        after calling this function.
+
+        Parameters
+        ----------
+        calculation_id : str
+            The calculation ID of the command.
+        exception : Exception
+            The exception raised by the command.
+
+        """
+        status_details = CalculationStatusDetails(
+            calculation_id=calculation_id,
+            status=CalculationStatusEnum.FAILED,
+            stdout="",
+            stderr="",
+            extra_info={"error_msg": f"Exception raised in background task: {exception!r}"},
+        )
+        await update_calculation_status_in_nats_kv(status_details)
+        # Set client back to being idle, otherwise we wouldn't be able to request
+        # new commands
+        self.status.set_idle()
 
     async def close_interactive_session(
         self, msg: msg_specs.CloseInteractiveSessionNATS
@@ -236,24 +263,33 @@ class QCrBoxClient(QCrBoxServerClientBase):
             )
             return response
 
-        calc = self.calculations[session_id]
+        try:
+            calc = self.calculations[session_id]
+        except KeyError:
+            logger.error(f"Unable to find calculation with session_id={session_id!r}")
+            response = msg_specs.CloseInteractiveSessionResponseNATS(
+                session_id=session_id, status=CalculationStatusEnum.FAILED, output_dataset_id=None
+            )
+            return response
+
+        logger.debug(f"Attempting to close interactive session: {calc}")
         try:
             await calc.terminate()
             self.status.set_idle()  # Set status to idle so container can be re-used
         except AttributeError:
             logger.error(f"Calculation {session_id!r} is not an interactive session")
-            response = msg_specs.CloseInteractiveSessionNATS(
+            response = msg_specs.CloseInteractiveSessionResponseNATS(
                 session_id=session_id, status=CalculationStatusEnum.FAILED, output_dataset_id=None
             )
             return response
 
-        msg = msg_specs.CloseInteractiveSessionResponseNATS(
+        response = msg_specs.CloseInteractiveSessionResponseNATS(
             session_id=session_id,
             status=calc.status,
             output_dataset_id=calc.output_dataset_id,
         )
 
-        return msg
+        return response
 
     async def get_calculation_status(
         self, msg: msg_specs.GetCalculationStatusNATS
@@ -280,7 +316,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         )
         return response
 
-    def get_executable_command(self, command_name):
+    def get_executable_command(self, command_name: str) -> BaseCommand:
         """Retrieve an executable command object by its name.
 
         Parameters

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -9,6 +9,11 @@ from litestar import Litestar
 from pyqcrbox import helpers, logger, msg_specs, settings, sql_models
 from pyqcrbox.helpers import generate_private_routing_key
 from pyqcrbox.registry.client.executable_command.base_calculation import BaseCalculation
+from pyqcrbox.registry.client.executable_command.error import (
+    FinaliseCommandFailure,
+    PrepareCommandFailure,
+    RunCommandFailure,
+)
 from pyqcrbox.registry.client.executable_command.interactive_session_calculation import InteractiveSessionCalculation
 from pyqcrbox.registry.shared.calculation_status import update_calculation_status_in_nats_kv
 from pyqcrbox.services import get_data_file_manager
@@ -290,10 +295,23 @@ class QCrBoxClient(QCrBoxServerClientBase):
             )
             return response
 
+        if calc.exception:
+            if isinstance(calc.exception, PrepareCommandFailure):
+                error_msg = f"Prepare step failed: {calc.exception.original_exception}"
+            elif isinstance(calc.exception, RunCommandFailure):
+                error_msg = f"Run step failed: {calc.exception.original_exception}"
+            elif isinstance(calc.exception, FinaliseCommandFailure):
+                error_msg = f"Fianalise step failed: {calc.exception.original_exception}"
+            else:
+                error_msg = f"Command failed: {calc.exception}"
+        else:
+            error_msg = None
+
         response = msg_specs.CloseInteractiveSessionResponseNATS(
             session_id=session_id,
             status=calc.status,
             output_dataset_id=calc.output_dataset_id,
+            error_msg=error_msg,
         )
 
         return response

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
@@ -217,7 +217,8 @@ async def invoke_command(data: sql_models.CommandInvocationCreate) -> dict:
     response_json = await nats_broker.publish(msg, "server.cmd.handle_command_invocation_by_user", rpc=True)
 
     if not response_json:
-        exc_msg = "No response from server when trying to invoke command"
+        exc_msg = f"No response from server when trying to invoke command: response_json {response_json}"
+        logger.error(f"{exc_msg}")
         raise ValueError(exc_msg)
 
     return response_json

--- a/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
+++ b/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
@@ -335,7 +335,7 @@ class QCrBoxServer(QCrBoxServerClientBase):
             plugins=[structlog_plugin],
             openapi_config=OpenAPIConfig(
                 title="QCrBox",
-                version="0.2.1",
+                version="0.2.2",
                 use_handler_docstrings=True,
             ),
             exception_handlers={

--- a/pyqcrbox/robot_tests/api_endpoints.robot
+++ b/pyqcrbox/robot_tests/api_endpoints.robot
@@ -265,7 +265,7 @@ Check /interactive-sessions/id can close an interactive session
     Should Be Equal As Integers    ${n_sessions}    1    "Close interactive session should return the closed session"
 
     ${closed_session}=    Set Variable    ${interactive_sessions[0]}
-    Check Response Has Attributes    ${closed_session}    session_id    status    output_dataset_id
+    Check Response Has Attributes    ${closed_session}    session_id    status    output_dataset_id    error_msg
     Should Be Equal    ${closed_session["session_id"]}    ${TEST_INTERACTIVE_SESSION_ID}
 
 Check /interactive-sessions can open a new session after the last was closed
@@ -301,7 +301,7 @@ Check /interactive-sessions can open a new session after the last was closed
     Should Be Equal As Integers    ${n_sessions}    1    "Close interactive session should return the closed session"
 
     ${closed_session}=    Set Variable    ${interactive_sessions[0]}
-    Check Response Has Attributes    ${closed_session}    session_id    status    output_dataset_id
+    Check Response Has Attributes    ${closed_session}    session_id    status    output_dataset_id    error_msg
     Should Be Equal    ${closed_session["session_id"]}    ${invoke_payload['interactive_session_id']}
 
 #

--- a/services/applications/olex2_linux/config_olex2.yaml
+++ b/services/applications/olex2_linux/config_olex2.yaml
@@ -27,15 +27,15 @@ commands:
         import_path: "configure_olex2"
         callable_name: "prepare__interactive"
         used_basecommand_parameters: ["input_file"]
-      # run:
-      #   implemented_as: "cli_command"
-      #   call_pattern: "/bin/bash /opt/olex2/start {input_file}"
-      #   used_basecommand_parameters: ["input_file"]
       run:
-        implemented_as: "python_callable"
-        import_path: "configure_olex2"
-        callable_name: "run__interactive"
+        implemented_as: "cli_command"
+        call_pattern: "/bin/bash /opt/olex2/start {input_file}"
         used_basecommand_parameters: ["input_file"]
+      # run:
+      #   implemented_as: "python_callable"
+      #   import_path: "configure_olex2"
+      #   callable_name: "run__interactive"
+      #   used_basecommand_parameters: ["input_file"]
       finalise:
         implemented_as: "python_callable"
         import_path: "configure_olex2"

--- a/services/applications/olex2_linux/configure_olex2.py
+++ b/services/applications/olex2_linux/configure_olex2.py
@@ -47,13 +47,12 @@ def prepare__interactive(input_file):
     # Create a backup of the original input file
     shutil.copyfile(input_cif_path, input_cif_path.with_suffix(".cif.bak"))
     # Copy the input file to the work file
-    # try:
-    #     shutil.copyfile(input_cif_path, work_cif_path)
-    # except shutil.SameFileError:
-    #     logger.error(
-    #         f"XXX DEBUG MODE: same file error probably due to a previous workflow failure: path={input_cif_path}",
-    #     )
-    shutil.copyfile(input_cif_path, input_cif_path)
+    try:
+        shutil.copyfile(input_cif_path, work_cif_path)
+    except shutil.SameFileError:
+        logger.error(
+            f"XXX DEBUG MODE: same file error probably due to a previous workflow failure: path={input_cif_path}",
+        )
 
 
 def finalise__interactive(input_file):

--- a/services/applications/olex2_linux/configure_olex2.py
+++ b/services/applications/olex2_linux/configure_olex2.py
@@ -47,12 +47,13 @@ def prepare__interactive(input_file):
     # Create a backup of the original input file
     shutil.copyfile(input_cif_path, input_cif_path.with_suffix(".cif.bak"))
     # Copy the input file to the work file
-    try:
-        shutil.copyfile(input_cif_path, work_cif_path)
-    except shutil.SameFileError:
-        logger.error(
-            f"XXX DEBUG MODE: same file error probably due to a previous workflow failure: path={input_cif_path}",
-        )
+    # try:
+    #     shutil.copyfile(input_cif_path, work_cif_path)
+    # except shutil.SameFileError:
+    #     logger.error(
+    #         f"XXX DEBUG MODE: same file error probably due to a previous workflow failure: path={input_cif_path}",
+    #     )
+    shutil.copyfile(input_cif_path, input_cif_path)
 
 
 def finalise__interactive(input_file):


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #462 

## Summary of the changes

This PR adds error dialog boxes in a VNC session when an error occurs in an interactive session. This works best when the prepare or run command failed, and also works for the finalise command but it is not clear due to how the user has to end the session before the finalise step can run.

The API responsible for closing interactive sessions will also return an "error_msg" property which contains the string representation of the exception; this should be the same error message displayed in the error dialog box. The API will also return an ERROR status when any of the steps fail.  

## How was it tested?

This was tested by adding exceptions to the configure scripts for Olex2.

- Robot tests for the API endpoints
- Robot tests for the API client
- Clicking in the frontend

## Additional considerations / follow-up work needed

If the finalise step fails, the error dialog does not show until the user presses "End Interactive Session" in the front end. By this time, they are no longer looking at the VNC window where the dialog box will show. This means the error may not be noticed by the user.

Perhaps we want to change the behaviour of how we trigger the finalise command, or @jmcourt can render any error message returned by the API on the frontend.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added automated tests for my changes
- [x] I updated any relevant documentation
- ~~- [ ] I created separate GitHub issues for any follow-up work needed~~

