### PR TITLE
Hot/bug fix for errors when ending interactive session early

### DIFF
--- a/pyqcrbox/pyqcrbox/msg_specs/msg_types/server_side/invoke_command_nats.py
+++ b/pyqcrbox/pyqcrbox/msg_specs/msg_types/server_side/invoke_command_nats.py
@@ -8,8 +8,8 @@ from pyqcrbox.sql_models import QCrBoxPydanticBaseModel
 
 
 class InvokeCommandNATS(QCrBoxPydanticBaseModel):
-    application_slug: str | None
-    application_version: str | None
+    application_slug: str
+    application_version: str
     command_name: str
     arguments: dict[str, Any]
 

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/base_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/base_calculation.py
@@ -21,7 +21,11 @@ class BaseCalculation(metaclass=ABCMeta):
     def __init__(self, *, calculation_id: str, calc_finished_event: anyio.Event) -> None:
         self.calculation_id = calculation_id
         self.calc_finished_event = calc_finished_event
-        self.exception = None
+
+        # These are for error tracking, specifically for recording the exception
+        # raised in an async sub-process and if the calculation was manually
+        # terminated
+        self.exception_raised = None
 
     def __repr__(self):
         """Return a string representation of the calculation instance.

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command_calculation.py
@@ -34,6 +34,8 @@ class CLICmdCalculation(BaseCalculation):
         self.retrieved_stdout_stderr = False
         self.calc_finished_event = calc_finished_event
 
+        self._terminated = False
+
     async def wait_until_finished(self):
         """Wait until the calculation is finished."""
         await self.proc.wait()
@@ -56,6 +58,11 @@ class CLICmdCalculation(BaseCalculation):
             The current status of the calculation.
 
         """
+        # If the process was terminated by the user, we will return the status
+        # SUCCESSFUL.
+        if self._terminated:
+            return CalculationStatusEnum.SUCCESSFUL
+
         match self.proc.returncode:
             case None:
                 status = CalculationStatusEnum.RUNNING
@@ -127,6 +134,7 @@ class CLICmdCalculation(BaseCalculation):
         """Terminate the calculation."""
         if self.proc:
             os.killpg(self.proc.pid, signal.SIGTERM)
+            self._terminated = True
             logger.debug(f"Terminated process for calculation {self!r}")
         else:
             logger.debug(f"No process running for calculation {self!r} - nothing to terminate.")

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command_calculation.py
@@ -31,14 +31,16 @@ class CLICmdCalculation(BaseCalculation):
         self.calculation_id = calculation_id
         self._stdout = ""
         self._stderr = ""
+        self._terminated = False
         self.retrieved_stdout_stderr = False
         self.calc_finished_event = calc_finished_event
-
-        self._terminated = False
 
     async def wait_until_finished(self):
         """Wait until the calculation is finished."""
         await self.proc.wait()
+
+        # Check the return status of the CLI command once the process has either
+        # finished naturally or if it was terminated early
         if self.status == CalculationStatusEnum.FAILED:
             logger.error(
                 f"CLI Command failed:\nStdout:\n\n{await self.stdout}\n\nStderr:\n\n{await self.stderr}",
@@ -46,6 +48,7 @@ class CLICmdCalculation(BaseCalculation):
             self.exception = RuntimeError(
                 f"CLI command failed with return code {self.proc.returncode}: {await self.stderr}"
             )
+
         self.calc_finished_event.set()
 
     @property
@@ -58,11 +61,11 @@ class CLICmdCalculation(BaseCalculation):
             The current status of the calculation.
 
         """
-        # If the process was terminated by the user, we will return the status
-        # SUCCESSFUL.
+        # Short-circuit to return SUCCESS when user terminated command
         if self._terminated:
             return CalculationStatusEnum.SUCCESSFUL
 
+        # Match status when command is still running, or when it exited normally
         match self.proc.returncode:
             case None:
                 status = CalculationStatusEnum.RUNNING
@@ -85,13 +88,14 @@ class CLICmdCalculation(BaseCalculation):
         return {"returncode": self.returncode}
 
     @property
-    def returncode(self) -> int:
+    def returncode(self) -> int | None:
         """Get the return code of the CLI command process.
 
         Returns
         -------
-        int
-            The return code of the process.
+        int | None
+            The return code of the process. If the process is still running, the
+            return code will be None.
 
         """
         return self.proc.returncode
@@ -131,7 +135,16 @@ class CLICmdCalculation(BaseCalculation):
             self.retrieved_stdout_stderr = True
 
     async def terminate(self):
-        """Terminate the calculation."""
+        """Terminate the calculation.
+
+        Once the process has been terminated, self.proc.wait() will no longer be
+        blocking. This means that in `self.wait_until_finished()`, the return code
+        of the process will be used to determine if it failed or not. This is why
+        self._terminated exists. It allows us to short-circuit looking up the
+        process status to return SUCCESSFUL if the user chooses to terminate. Before
+        doing this, the return code may by -15 (SIGTERM) which would (falsely)
+        flag the process as failing.
+        """
         if self.proc:
             os.killpg(self.proc.pid, signal.SIGTERM)
             self._terminated = True

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/executable_command.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/executable_command.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 from pyqcrbox.sql_models.command_spec import ImplementedAs
 
-from .base_command import BaseCommand
 from .cli_command import CLICommand
 from .interactive_session import InteractiveSession
 from .python_callable import PythonCallable
@@ -13,7 +12,9 @@ if TYPE_CHECKING:
 __all__ = ["ExecutableCommand"]
 
 
-def ExecutableCommand(cmd_spec: "CommandSpecDiscriminatedUnion", **kwargs) -> BaseCommand:
+def ExecutableCommand(
+    cmd_spec: "CommandSpecDiscriminatedUnion", **kwargs
+) -> PythonCallable | CLICommand | InteractiveSession:
     """Instantiate a command implementation from a command specification.
 
     Parameters
@@ -25,7 +26,7 @@ def ExecutableCommand(cmd_spec: "CommandSpecDiscriminatedUnion", **kwargs) -> Ba
 
     Returns
     -------
-    BaseCommand
+    PythonCallable | CLICommand | InteractiveSession
         An instance of the appropriate command class based on the implementation type.
 
     Raises

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -137,16 +137,18 @@ class InteractiveSession(BaseCommand):
                     **param_values,
                 )
                 await interactive_session_calc.prepare_calc.wait_until_finished()
-                if interactive_session_calc.prepare_calc.exception:
+                if interactive_session_calc.prepare_calc.exception_raised:
                     calc_status = interactive_session_calc.prepare_calc.status
-                    raised_exception = interactive_session_calc.prepare_calc.exception
+                    raised_exception = interactive_session_calc.prepare_calc.exception_raised
                     logger.error(
                         f"Exception raised by prepare_cmd (calc status {calc_status}): {raised_exception}",
                     )
-                    error_dialog_box(f"An error occurred in the prepare command: {raised_exception}")
+                    interactive_session_calc._error_dialog_process = error_dialog_box(
+                        f"An error occurred in the prepare command: {raised_exception}"
+                    )
                     raise PrepareCommandFailure(
-                        "Prepare command failed", interactive_session_calc.prepare_calc.exception
-                    ) from interactive_session_calc.prepare_calc.exception
+                        "Prepare command failed", interactive_session_calc.prepare_calc.exception_raised
+                    ) from interactive_session_calc.prepare_calc.exception_raised
                 logger.debug("Prepare command has finished executing")
 
             # Run the main interactive command (run command), wait for it to finish
@@ -158,16 +160,18 @@ class InteractiveSession(BaseCommand):
                 **param_values,
             )
             await interactive_session_calc.run_calc.wait_until_finished()
-            if interactive_session_calc.run_calc.exception:
+            if interactive_session_calc.run_calc.exception_raised:
                 calc_status = interactive_session_calc.run_calc.status
-                raised_exception = interactive_session_calc.run_calc.exception
+                raised_exception = interactive_session_calc.run_calc.exception_raised
                 logger.error(
                     f"Exception raised by run_cmd (calc status {calc_status}): {raised_exception}",
                 )
-                error_dialog_box(f"An error occurred in the run command: {raised_exception}")
+                interactive_session_calc._error_dialog_process = error_dialog_box(
+                    f"An error occurred in the run command: {raised_exception}"
+                )
                 raise RunCommandFailure(
-                    "Run command failed", interactive_session_calc.run_calc.exception
-                ) from interactive_session_calc.run_calc.exception
+                    "Run command failed", interactive_session_calc.run_calc.exception_raised
+                ) from interactive_session_calc.run_calc.exception_raised
             logger.debug("Run command has finished executing")
 
             # Launch finalise command, but don't wait for it to finish. We wait for this

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -7,6 +7,7 @@ import anyio
 
 from pyqcrbox import helpers, logger
 from pyqcrbox.registry.client.executable_command import BaseCommand
+from pyqcrbox.registry.client.executable_command.cli_command import CLICommand
 from pyqcrbox.registry.client.executable_command.error import PrepareCommandFailure, RunCommandFailure, error_dialog_box
 from pyqcrbox.registry.client.executable_command.python_callable import PythonCallable
 from pyqcrbox.sql_models import InteractiveSessionSpec
@@ -27,6 +28,149 @@ class InteractiveSession(BaseCommand):
         self._prepare_cmd = None
         self._run_cmd = None
         self._finalise_cmd = None
+
+    @staticmethod
+    async def _execute_prepare_command(
+        command: PythonCallable,
+        working_directory: str | Path | None,
+        session_calculation: InteractiveSessionCalculation,
+        **param_values: dict[str, Any],
+    ) -> None:
+        """Launch and execute the prepare command for this interactive session.
+
+        For the prepare command, only PythonCallable's are supported. This will
+        launch the prepare command in the background and wait for execution to
+        finish. The calculation object returned for the command is stored
+        in the calculation object for the interactive session passed to this
+        function.
+
+        Parameters
+        ----------
+        command : PythonCallable
+            A PythonCallable object containing the command instructions.
+        working_directory : str | Path | None
+            The working directory for the command to run in.
+        session_calculation : InteractiveSessionCalculation
+            The calculation object for the interactive session.
+        param_values : dict[str, Any]
+            Any keyword arguments which will be passed as parameters for the
+            command to run.
+
+        """
+        if not isinstance(command, PythonCallable):
+            raise TypeError("Only `PythonCallable` is supported for 'prepare_cmd'")
+        logger.debug(f"Executing prepare command in background and waiting for it to finish: {command}")
+
+        session_calculation.prepare_calc = await command.execute_in_background(
+            _calculation_id=helpers.generate_calculation_id(),
+            _cwd=working_directory,
+            _num_processes=1,
+            **param_values,
+        )
+        await session_calculation.prepare_calc.wait_until_finished()
+
+        if session_calculation.prepare_calc.exception_raised:
+            exception = session_calculation.prepare_calc.exception_raised
+            session_calculation._error_dialog_process = error_dialog_box(
+                f"An error occurred in the prepare command: {exception}"
+            )
+            # PrepareCommandFailure requires the original exception for better error
+            # reporting upstream
+            raise PrepareCommandFailure(
+                "Prepare command failed", session_calculation.prepare_calc.exception_raised
+            ) from exception
+
+        logger.debug("Prepare command has finished")
+
+    @staticmethod
+    async def _execute_run_command(
+        command: CLICommand | PythonCallable,
+        working_directory: str | Path | None,
+        session_calculation: InteractiveSessionCalculation,
+        **param_values: dict[str, Any],
+    ) -> None:
+        """Launch and execute the run command for this interactive session.
+
+        For the run command, CLICommand's and PythonCallable's are supported.
+        This will launch the runcommand in the background and wait for execution
+        to finish. The calculation object returned for the command is stored
+        in the calculation object for the interactive session passed to this
+        function.
+
+        Parameters
+        ----------
+        command : CLICommand | PythonCallable
+            A CLICommand or PythonCallable object containing the command
+            instructions.
+        working_directory : str | Path | None
+            The working directory for the command to run in.
+        session_calculation : InteractiveSessionCalculation
+            The calculation object for the interactive session.
+        param_values : dict[str, Any]
+            Any keyword arguments which will be passed as parameters for the
+            command to run.
+
+        """
+        if not isinstance(command, CLICommand | PythonCallable):
+            raise TypeError("Only `CLICommand` or `PythonCallable` are supported for 'run_cmd'")
+        logger.debug(f"Executing run command in background and waiting for it to finish: {command}")
+
+        session_calculation.run_calc = await command.execute_in_background(
+            _calculation_id=helpers.generate_calculation_id(),
+            _cwd=working_directory,
+            **param_values,
+        )
+        await session_calculation.run_calc.wait_until_finished()
+
+        if session_calculation.run_calc.exception_raised:
+            exception = session_calculation.run_calc.exception_raised
+            session_calculation._error_dialog_process = error_dialog_box(
+                f"An error occurred in the run command: {exception}"
+            )
+            # RunCommandFailure requires the original exception for better error
+            # reporting upstream
+            raise RunCommandFailure("Run command failed", exception) from exception
+
+        logger.debug("Run command has finished")
+
+    @staticmethod
+    async def _launch_finalise_command(
+        command: PythonCallable,
+        working_directory: str | Path | None,
+        session_calculation: InteractiveSessionCalculation,
+        **param_values: dict[str, Any],
+    ):
+        """Launch the finalise command for this interactive session.
+
+        For the finalise command, only PythonCallable's are supported. This will
+        launch the finalise command in the background and DOES NOT wait for it
+        to finish. The calculation object returned for the command is stored
+        in the calculation object for the interactive session passed to this
+        function.
+
+        Parameters
+        ----------
+        command : CLICommand | PythonCallable
+            A CLICommand or PythonCallable object containing the command
+            instructions.
+        working_directory : str | Path | None
+            The working directory for the command to run in.
+        session_calculation : InteractiveSessionCalculation
+            The calculation object for the interactive session.
+        param_values : dict[str, Any]
+            Any keyword arguments which will be passed as parameters for the
+            command to run.
+
+        """
+        if not isinstance(command, PythonCallable):
+            raise TypeError("Only `PythonCallable` is supported for 'finalise_cmd'")
+        logger.debug(f"Executing finalise command in background: {command}")
+
+        session_calculation.finalise_calc = await command.execute_in_background(
+            _calculation_id=helpers.generate_calculation_id(),
+            _cwd=working_directory,
+            **param_values,
+        )
 
     async def prepare_parameters_for_command_execution(
         self, working_dir: str | Path, **kwargs: dict[str, Any]
@@ -108,7 +252,8 @@ class InteractiveSession(BaseCommand):
         interactive_session_calc = InteractiveSessionCalculation(
             calculation_id=_calculation_id,
             calc_finished_event=calc_finished_event,
-            async_task=None,  # the following will be set after the task begins
+            # the following will be set after the task begins
+            async_task=None,
             prepare_calc=None,
             run_calc=None,
             finalise_calc=None,
@@ -118,74 +263,18 @@ class InteractiveSession(BaseCommand):
         prepare_cmd = ExecutableCommand(self.prepare_cmd_spec) if self.prepare_cmd_spec else None
         finalise_cmd = ExecutableCommand(self.finalise_cmd_spec) if self.finalise_cmd_spec else None
 
-        # Bit of a terrible hack to do this, but it seems to be OK. Essentially we are
-        # creating a task to run which we then use anyio.create_task to run asynchronously
+        # Create a task to run which will use asyncio.create_task to run asynchronously
         # in the background. By doing this we can return an InteractiveSessionCalculation
         # before the run_calc has finished and thus should be able to terminate the
         # calculation.
-        async def session_tasks():
+        async def background_task():
             nonlocal run_cmd, prepare_cmd, finalise_cmd
-
-            # Run prepare command, wait for it to finish, and handle errors
             if prepare_cmd:
-                if not isinstance(prepare_cmd, PythonCallable):
-                    raise TypeError("Only `PythonCallable` is supported for 'prepare_cmd'")
-                logger.debug(f"Executing prepare command in background and waiting for it to finish: {prepare_cmd}")
-                interactive_session_calc.prepare_calc = await prepare_cmd.execute_in_background(
-                    _calculation_id=helpers.generate_calculation_id(),
-                    _cwd=_cwd,
-                    **param_values,
-                )
-                await interactive_session_calc.prepare_calc.wait_until_finished()
-                if interactive_session_calc.prepare_calc.exception_raised:
-                    calc_status = interactive_session_calc.prepare_calc.status
-                    raised_exception = interactive_session_calc.prepare_calc.exception_raised
-                    logger.error(
-                        f"Exception raised by prepare_cmd (calc status {calc_status}): {raised_exception}",
-                    )
-                    interactive_session_calc._error_dialog_process = error_dialog_box(
-                        f"An error occurred in the prepare command: {raised_exception}"
-                    )
-                    raise PrepareCommandFailure(
-                        "Prepare command failed", interactive_session_calc.prepare_calc.exception_raised
-                    ) from interactive_session_calc.prepare_calc.exception_raised
-                logger.debug("Prepare command has finished executing")
-
-            # Run the main interactive command (run command), wait for it to finish
-            # and handle errors
-            logger.debug(f"Executing run command in background and waiting for it to finish: {run_cmd}")
-            interactive_session_calc.run_calc = await run_cmd.execute_in_background(
-                _calculation_id=helpers.generate_calculation_id(),
-                _cwd=_cwd,
-                **param_values,
-            )
-            await interactive_session_calc.run_calc.wait_until_finished()
-            if interactive_session_calc.run_calc.exception_raised:
-                calc_status = interactive_session_calc.run_calc.status
-                raised_exception = interactive_session_calc.run_calc.exception_raised
-                logger.error(
-                    f"Exception raised by run_cmd (calc status {calc_status}): {raised_exception}",
-                )
-                interactive_session_calc._error_dialog_process = error_dialog_box(
-                    f"An error occurred in the run command: {raised_exception}"
-                )
-                raise RunCommandFailure(
-                    "Run command failed", interactive_session_calc.run_calc.exception_raised
-                ) from interactive_session_calc.run_calc.exception_raised
-            logger.debug("Run command has finished executing")
-
-            # Launch finalise command, but don't wait for it to finish. We wait for this
-            # to finish in the interactive session calculation
+                await self._execute_prepare_command(prepare_cmd, _cwd, interactive_session_calc, **param_values)
+            await self._execute_run_command(run_cmd, _cwd, interactive_session_calc, **param_values)
             if finalise_cmd:
-                if not isinstance(finalise_cmd, PythonCallable):
-                    raise TypeError("Only `PythonCallable` is supported for 'finalise_cmd'")
-                logger.debug(f"Executing finalise command in background: {finalise_cmd}")
-                interactive_session_calc.finalise_calc = await finalise_cmd.execute_in_background(
-                    _calculation_id=helpers.generate_calculation_id(),
-                    _cwd=_cwd,
-                    **param_values,
-                )
+                await self._launch_finalise_command(finalise_cmd, _cwd, interactive_session_calc, **param_values)
 
-        interactive_session_calc.background_task = asyncio.create_task(session_tasks())
+        interactive_session_calc.background_task = asyncio.create_task(background_task())
 
         return interactive_session_calc

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -3,10 +3,7 @@ import asyncio
 import anyio
 
 from pyqcrbox import logger
-from pyqcrbox.registry.client.executable_command.error import (
-    FinaliseCommandFailure,
-    error_dialog_box,
-)
+from pyqcrbox.registry.client.executable_command.error import FinaliseCommandFailure, error_dialog_box
 from pyqcrbox.services import get_data_file_manager
 from pyqcrbox.sql_models import CalculationStatusEnum
 
@@ -73,6 +70,9 @@ class InteractiveSessionCalculation(BaseCalculation):
             If the output file from the 'finalise' command cannot be found during import.
 
         """
+        if not self.background_task:
+            raise RuntimeError("There is no background task(s) to wait to finish")
+
         # await the background task so we can capture any exceptions which were raised
         # in it and re-raise them to propagate them back up
         try:
@@ -146,12 +146,12 @@ class InteractiveSessionCalculation(BaseCalculation):
         # Terminate the prepare and run calculation if still running. Then we need to set the 'calc_finished'
         # event which *should* cause run_calc.wait_until_finished() to exit. If this flag isn't set, then
         # execution will hang
-        if self.prepare_calc == CalculationStatusEnum.RUNNING:
-            logger.debug("Terminating prepare command in InteractiveSessionCalculation.terminate()")
+        if self.prepare_calc and self.prepare_calc.status == CalculationStatusEnum.RUNNING:
             await self.prepare_calc.terminate()
+
         if self.run_calc.status == CalculationStatusEnum.RUNNING:
-            logger.debug("Terminating run command in InteractiveSessionCalculation.terminate()")
             await self.run_calc.terminate()
+
         self.run_calc.calc_finished_event.set()
 
         # When the run calc is finished, this flag is used to communicate with the interactive

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -3,7 +3,10 @@ import asyncio
 import anyio
 
 from pyqcrbox import logger
-from pyqcrbox.registry.client.executable_command.error import FinaliseCommandFailure, error_dialog_box
+from pyqcrbox.registry.client.executable_command.error import (
+    FinaliseCommandFailure,
+    error_dialog_box,
+)
 from pyqcrbox.services import get_data_file_manager
 from pyqcrbox.sql_models import CalculationStatusEnum
 
@@ -31,11 +34,14 @@ class InteractiveSessionCalculation(BaseCalculation):
         self.output_dataset_id = None
         self.session_closed_event = anyio.Event()
 
+        # for keeping track of error pop ups
+        self._error_dialog_process = None
+
     @property
     def status(self) -> CalculationStatusEnum:
         if not self.is_closed:
             return CalculationStatusEnum.RUNNING
-        elif self.exception:
+        elif self.exception_raised:
             return CalculationStatusEnum.FAILED
         else:
             return CalculationStatusEnum.SUCCESSFUL
@@ -87,12 +93,16 @@ class InteractiveSessionCalculation(BaseCalculation):
             assert isinstance(self.finalise_calc, PythonCallableCalculation)
             logger.debug(f"Waiting for 'finalise' command to finish: {self.finalise_calc!r}")
             await self.finalise_calc.wait_until_finished()
-            if self.finalise_calc.exception:
+            if self.finalise_calc.exception_raised:
                 calc_status = self.finalise_calc.status
-                logger.error(f"Exception raised by finalise_cmd ({calc_status}): {self.finalise_calc.exception!r}")
-                error_dialog_box(f"An error occurred in the finalise command: {self.finalise_calc.exception}")
-                self.exception = FinaliseCommandFailure("Finalise command failed", self.finalise_calc.exception)
-                raise self.exception from self.finalise_calc.exception
+                logger.error(
+                    f"Exception raised by finalise_cmd ({calc_status}): {self.finalise_calc.exception_raised!r}"
+                )
+                self._error_dialog_process = error_dialog_box(
+                    f"An error occurred in the finalise command: {self.finalise_calc.exception_raised}"
+                )
+                self.exception = FinaliseCommandFailure("Finalise command failed", self.finalise_calc.exception_raised)
+                raise self.exception from self.finalise_calc.exception_raised
             logger.debug("Finalise command has finished")
 
             # The above will only run if the finalise calc finished successfully, e.g.
@@ -124,6 +134,7 @@ class InteractiveSessionCalculation(BaseCalculation):
         returns. Otherwise, it signals the calculation to finish, waits for
         session closure.
         """
+        self.terminated_manually = True
         if self.calc_finished_event.is_set():
             if self.is_closed:
                 logger.warning(f"Interactive session {self} already closed")
@@ -150,3 +161,8 @@ class InteractiveSessionCalculation(BaseCalculation):
         # Keep waiting until the finalise calculation has finished and the output has been added to
         # the data store
         await self.session_closed_event.wait()
+
+        # Close any error dialog we have open, otherwise it gets confusing
+        if self._error_dialog_process:
+            self._error_dialog_process.terminate()
+            self._error_dialog_process.join()

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
@@ -38,7 +38,7 @@ class PythonCallableCalculation(BaseCalculation):
         self._apply_result = result
         self.pool = pool
         self.return_value = None
-        self.exception = None
+        self._terminated = False
 
     async def wait_until_finished(self):
         """Wait until the calculation is finished."""
@@ -55,6 +55,9 @@ class PythonCallableCalculation(BaseCalculation):
             The current status of the calculation.
 
         """
+        if self._terminated:
+            return CalculationStatusEnum.SUCCESSFUL
+
         if self._apply_result.ready():
             if self._apply_result.successful():
                 self.return_value = self._apply_result.get()
@@ -66,7 +69,7 @@ class PythonCallableCalculation(BaseCalculation):
                 try:
                     self._apply_result.get()
                 except Exception as exc:
-                    self.exception = exc
+                    self.exception_raised = exc
             # When the result is ready, we can close the pool normally without
             # having to forcefully terminate the process and child processes
             # by hand
@@ -125,4 +128,5 @@ class PythonCallableCalculation(BaseCalculation):
             for child in child_processes:
                 child.terminate()
             process.terminate()
+        self._terminated = True
         logger.debug("Multiprocessing pool terminated.")

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
@@ -55,6 +55,7 @@ class PythonCallableCalculation(BaseCalculation):
             The current status of the calculation.
 
         """
+        # Short-circuit to return SUCCESS when user terminated command
         if self._terminated:
             return CalculationStatusEnum.SUCCESSFUL
 
@@ -70,12 +71,11 @@ class PythonCallableCalculation(BaseCalculation):
                     self._apply_result.get()
                 except Exception as exc:
                     self.exception_raised = exc
-            # When the result is ready, we can close the pool normally without
-            # having to forcefully terminate the process and child processes
-            # by hand
             logger.debug(
                 f"Calculation {self.calculation_id} finished with status {calc_status}, closing multiprocessing pool",
             )
+            # When the result is ready, we can close the pool normally without having to forcefully
+            # terminate the process and child processes by hand
             self.pool.close()
             self.pool.join()
         else:

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -295,15 +295,15 @@ class QCrBoxClient(QCrBoxServerClientBase):
             )
             return response
 
-        if calc.exception:
-            if isinstance(calc.exception, PrepareCommandFailure):
-                error_msg = f"Prepare step failed: {calc.exception.original_exception}"
-            elif isinstance(calc.exception, RunCommandFailure):
-                error_msg = f"Run step failed: {calc.exception.original_exception}"
-            elif isinstance(calc.exception, FinaliseCommandFailure):
-                error_msg = f"Fianalise step failed: {calc.exception.original_exception}"
+        if calc.exception_raised:
+            if isinstance(calc.exception_raised, PrepareCommandFailure):
+                error_msg = f"Prepare step failed: {calc.exception_raised.original_exception}"
+            elif isinstance(calc.exception_raised, RunCommandFailure):
+                error_msg = f"Run step failed: {calc.exception_raised.original_exception}"
+            elif isinstance(calc.exception_raised, FinaliseCommandFailure):
+                error_msg = f"Fianalise step failed: {calc.exception_raised.original_exception}"
             else:
-                error_msg = f"Command failed: {calc.exception}"
+                error_msg = f"Command failed: {calc.exception_raised}"
         else:
             error_msg = None
 

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -156,39 +156,37 @@ class QCrBoxClient(QCrBoxServerClientBase):
 
         """
         logger.info(f"Received command execution request: {msg!r} (current status: {self.status.status})")
-
         if self.status.status != ClientStatusEnum.PENDING:
             logger.error(
                 f"Trying to execute a command when client is not PENDING (current status: {self.status.status})"
             )
             return
         self.status.set_busy()
+        await self.add_interactive_session_to_db(msg)
 
-        await self.add_interactive_session_to_database(msg)
-
+        calc = None
         try:
-            cmd = self.get_executable_command(msg.command_name)
+            command = self.get_executable_command(msg.command_name)
             # Parse each argument in `msg.arguments` as the correct parameter type
             # Steps:
             #   - get the command spec and look up parameter types for each argument
             #   - parse each argument as the correct type
             parsed_args = {}
             for param_name, value in msg.arguments.items():
-                param_dtype_str = cmd.cmd_spec.get_parameter_by_name(param_name).dtype
+                param_dtype_str = command.cmd_spec.get_parameter_by_name(param_name).dtype
                 parsed_args[param_name] = parse_parameter_as_its_dtype(value, param_dtype_str)
-            logger.debug(f"Executing calculation in the background: {cmd!r}")
-            calc = await cmd.execute_in_background(
+
+            logger.debug(f"Executing calculation in the background: {command!r}")
+            calc = await command.execute_in_background(
                 **parsed_args, _calculation_id=msg.calculation_id, _cwd=self.working_dir
             )
             if not isinstance(calc, BaseCalculation):
                 raise RuntimeError("Command execution did not return a calculation object.")
-            logger.debug(f"Executing command has returned calculation: {calc!r}")
         except Exception as exc:
-            logger.debug("cmd.execute_in_background() raised an exception")
-            logger.error(
-                f"Command failed in background task with exception: {exc!r}",
-            )
-            await self.handle_command_execution_exception(msg.calculation_id, exc)
+            logger.error(f"Command failed in background task with exception: {exc!r}")
+            # calc will be unbound if execute_in_background fails
+            if calc:
+                await self.handle_command_execution_exception(calc, exc)
             return
 
         # Keep track of the calculation, which should still be running
@@ -199,19 +197,13 @@ class QCrBoxClient(QCrBoxServerClientBase):
         try:
             await calc.wait_until_finished()
         except Exception as exc:
-            logger.debug("calc.wait_until_finished() raised an exception")
-            logger.error(
-                f"Calculation failed in background task with exception: {exc!r}",
-            )
-            if isinstance(calc, InteractiveSessionCalculation):
-                calc.is_closed = True
-                calc.session_closed_event.set()
-            await self.handle_command_execution_exception(msg.calculation_id, exc)
+            logger.error(f"Calculation failed in background task with exception: {exc!r}")
+            await self.handle_command_execution_exception(calc, exc)
             return
 
         await update_calculation_status_in_nats_kv(await calc.get_status_details())
 
-    async def handle_command_execution_exception(self, calculation_id: str, exception: Exception) -> None:
+    async def handle_command_execution_exception(self, calculation: BaseCalculation, exception: Exception) -> None:
         """Handle a command execution error.
 
         This updates the calculation status to FAILED and sets the client back to
@@ -220,22 +212,29 @@ class QCrBoxClient(QCrBoxServerClientBase):
 
         Parameters
         ----------
-        calculation_id : str
-            The calculation ID of the command.
+        calculation: BaseCalculation
+            The calculation which failed.
         exception : Exception
             The exception raised by the command.
 
         """
+        # Handle any special cases where something extra needs to be done.
+        #   - Interactive sessions: need to set flags to indicate that the
+        #      session has finished.
+        if isinstance(calculation, InteractiveSessionCalculation):
+            calculation.session_closed_event.set()
+            calculation.is_closed = True
+
         status_details = CalculationStatusDetails(
-            calculation_id=calculation_id,
+            calculation_id=calculation.calculation_id,
             status=CalculationStatusEnum.FAILED,
             stdout="",
             stderr="",
             extra_info={"error_msg": f"Exception raised in background task: {exception!r}"},
         )
         await update_calculation_status_in_nats_kv(status_details)
-        # Set client back to being idle, otherwise we wouldn't be able to request
-        # new commands
+
+        # Set client back to being idle, otherwise it won't accept new requests
         logger.debug("Setting client status to idle in handle_command_execution_exception")
         self.status.set_idle()
 
@@ -261,13 +260,11 @@ class QCrBoxClient(QCrBoxServerClientBase):
             A NATS response containing the status and dataset ID for any output.
 
         """
+        session_id = msg.session_id
         logger.info(f"Received request to close interactive session: {msg!r}")
 
-        session_id = msg.session_id
-
         if session_id not in self.calculations:
-            logger.error(f"No calculations on client found for {session_id!r}")
-            logger.debug(f"Calculations in client: {self.calculations.keys()}")
+            logger.error(f"Calculation not found in client for {session_id!r}")
             response = msg_specs.CloseInteractiveSessionResponseNATS(
                 session_id=session_id,
                 status=CalculationStatusEnum.FAILED,
@@ -275,26 +272,43 @@ class QCrBoxClient(QCrBoxServerClientBase):
             )
             return response
 
-        try:
-            calc = self.calculations[session_id]
-        except KeyError:
-            logger.error(f"Unable to find calculation with session_id={session_id!r}")
-            response = msg_specs.CloseInteractiveSessionResponseNATS(
-                session_id=session_id, status=CalculationStatusEnum.FAILED, output_dataset_id=None
-            )
-            return response
-
+        calc = self.calculations[session_id]
         logger.debug(f"Attempting to close interactive session: {calc}")
         try:
             await calc.terminate()
             self.status.set_idle()  # Set status to idle so container can be re-used
         except AttributeError:
-            logger.error(f"Calculation {session_id!r} is not an interactive session")
+            logger.exception(f"Unable to terminate interactive session: {calc!r}")
             response = msg_specs.CloseInteractiveSessionResponseNATS(
                 session_id=session_id, status=CalculationStatusEnum.FAILED, output_dataset_id=None
             )
             return response
+        logger.debug("Interactive session has been closed")
 
+        response = msg_specs.CloseInteractiveSessionResponseNATS(
+            session_id=session_id,
+            status=calc.status,
+            output_dataset_id=calc.output_dataset_id,
+            error_msg=self.get_interactive_session_error_message(calc),
+        )
+
+        return response
+
+    @staticmethod
+    def get_interactive_session_error_message(calc: InteractiveSessionCalculation) -> str:
+        """Get an error message from an interactive session calculation.
+
+        Parameters
+        ----------
+        calc : InteractiveSessionCalculation
+            The calculation object for the interactive session being closed.
+
+        Returns
+        -------
+        str
+            The error message returned. This could be an empty string.
+
+        """
         if calc.exception_raised:
             if isinstance(calc.exception_raised, PrepareCommandFailure):
                 error_msg = f"Prepare step failed: {calc.exception_raised.original_exception}"
@@ -305,16 +319,9 @@ class QCrBoxClient(QCrBoxServerClientBase):
             else:
                 error_msg = f"Command failed: {calc.exception_raised}"
         else:
-            error_msg = None
+            error_msg = ""
 
-        response = msg_specs.CloseInteractiveSessionResponseNATS(
-            session_id=session_id,
-            status=calc.status,
-            output_dataset_id=calc.output_dataset_id,
-            error_msg=error_msg,
-        )
-
-        return response
+        return error_msg
 
     async def get_calculation_status(
         self, msg: msg_specs.GetCalculationStatusNATS
@@ -369,7 +376,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         for calc in self._calculations:
             await calc.terminate()
 
-    async def add_interactive_session_to_database(self, msg: msg_specs.CommandExecutionRequestNATS) -> None:
+    async def add_interactive_session_to_db(self, msg: msg_specs.CommandExecutionRequestNATS) -> None:
         """Add an interactive session to the database if applicable.
 
         Parameters

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -276,14 +276,14 @@ class QCrBoxClient(QCrBoxServerClientBase):
         logger.debug(f"Attempting to close interactive session: {calc}")
         try:
             await calc.terminate()
-            self.status.set_idle()  # Set status to idle so container can be re-used
         except AttributeError:
             logger.exception(f"Unable to terminate interactive session: {calc!r}")
             response = msg_specs.CloseInteractiveSessionResponseNATS(
                 session_id=session_id, status=CalculationStatusEnum.FAILED, output_dataset_id=None
             )
             return response
-        logger.debug("Interactive session has been closed")
+        self.status.set_idle()
+        logger.debug("Interactive session has been closed and client set to idle")
 
         response = msg_specs.CloseInteractiveSessionResponseNATS(
             session_id=session_id,


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #478 

## Summary of the changes

This adds a short-circuit to figuring out the status of a killed `CLICommand` and `PythonCallable`. In certain applications, sending `SIGTERM` would return a non-zero exit code of a `CLICommand` which would result in an error return from the API responsible for closing the interactive session. However, if a user request for the interactive session to be killed, it should not return a FAILED status because QCrBox did what the user requested.

Ending an interactive session before closing the GUI/interactive window should be a valid method of closing it. In this case, the finalise command will still run and output can be obtained.  

This PR will also add a fairly decent amount of documentation to explain the error handling better and command flow. It has also refactored parts of command and error handling code which helped increase the clarity of the issue, which made solving and fix the problem easier.

## How was it tested?

- Clicking in the frontend UI
- Robot tests for API endpoints

## Additional considerations / follow-up work needed

N/A, but this may become a talking point in the future when we add non-interactive commands.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I updated any relevant documentation
