### PR TITLE
Remove `deploy_docs` from workflow step for PRs

### DIFF
--- a/.github/workflows/qcrbox-ci.yml
+++ b/.github/workflows/qcrbox-ci.yml
@@ -44,6 +44,7 @@ jobs:
           path: .build/docs_site/
 
   deploy_docs:
+    if: github.event_name == 'push'
     needs: build_docs
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #471 

## Summary of the changes

This sets the `deploy_docs` steps to only be triggered on a push event to the `dev` or `main` branch.

## How was it tested?

Opening this PR and seeing if the step deployed.

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~
