### PR TITLE
Add dev server to allowed_hosts for qcrbox_quality

### DIFF
--- a/services/applications/qcrbox_quality/django_minimal.py
+++ b/services/applications/qcrbox_quality/django_minimal.py
@@ -22,7 +22,7 @@ BASE_DIR = Path(__file__).resolve().parent
 settings.configure(
     DEBUG=os.getenv("DEBUG", "False").lower() == "true",
     SECRET_KEY=os.getenv("SECRET_KEY", "your-secret-key-change-this-in-production"),
-    ALLOWED_HOSTS=os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(","),
+    ALLOWED_HOSTS=os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1,demo1.qcrbox.org").split(","),
     # Security settings
     SECURE_BROWSER_XSS_FILTER=True,
     SECURE_CONTENT_TYPE_NOSNIFF=True,


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #495


## Summary of the changes

- Added test server to the allowed_hosts list in the qrbox_quality visualiser's django app.

## How was it tested?


## Additional considerations / follow-up work needed


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- ~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
- ~~- [ ] I added automated tests for my changes~~
- ~~- [ ] I updated any relevant documentation~~
- ~~- [ ] I created separate GitHub issues for any follow-up work needed~~

- ~~- [ ] Example of a crossed-out item that does not apply to this PR~~
