### PR TITLE
Update default components for qcb up/build

### DIFF
--- a/pyqcrbox/pyqcrbox/cli/helpers/cli_helpers.py
+++ b/pyqcrbox/pyqcrbox/cli/helpers/cli_helpers.py
@@ -28,7 +28,7 @@ def add_verbose_option(f):
 
 def add_cli_option_to_enable_or_disable_components(f):
     DEFAULT_ALL_COMPONENTS = ("olex2", "crystal-explorer", "mopro", "qcrbox_quality", "xharpy-gpaw", "qcrboxtools")
-    DEFAULT_TEST_COMPONENTS = ("olex2",)
+    DEFAULT_TEST_COMPONENTS = ("olex2", "qcrbox_quality")
     DEFAULT_EXPLICITLY_ENABLED_COMPONENTS = ()
     DEFAULT_EXPLICITLY_DISABLED_COMPONENTS = ("shelx", "qcrbox-nextflow", "eval1x")
 

--- a/pyqcrbox/pyqcrbox/cli/helpers/cli_helpers.py
+++ b/pyqcrbox/pyqcrbox/cli/helpers/cli_helpers.py
@@ -27,7 +27,7 @@ def add_verbose_option(f):
 
 
 def add_cli_option_to_enable_or_disable_components(f):
-    DEFAULT_ALL_COMPONENTS = ("olex2", "crystal-explorer", "mopro")
+    DEFAULT_ALL_COMPONENTS = ("olex2", "crystal-explorer", "mopro", "qcrbox_quality", "xharpy-gpaw", "qcrboxtools")
     DEFAULT_TEST_COMPONENTS = ("olex2",)
     DEFAULT_EXPLICITLY_ENABLED_COMPONENTS = ()
     DEFAULT_EXPLICITLY_DISABLED_COMPONENTS = ("shelx", "qcrbox-nextflow", "eval1x")


### PR DESCRIPTION
## This PR addresses the following issue(s)

N/A

## Summary of the changes

Updates the list of default components when using `qcb up --all` or `qcb build --all` to match what in the previous demo, and to also include the `qcrbox_quality` container.

## How was it tested?

By running `qcb up --all` and looking at the frontend.

## Additional considerations / follow-up work needed

The build time is longer now, which is a bit of a pain. But one could use `qcb up --test-only` to only bring up the base container and olex2.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

~~- [ ] There is a GitHub issue describing the problem this PR is solving (please [create]~~(https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~

- ~~- [ ] Example of a crossed-out item that does not apply to this PR~~
