### PR TITLE
499 fix bug when skipping non applicable plots in qcrbox quality

### DIFF
--- a/services/applications/qcrbox_quality/quality_html/model_quality_summary.py
+++ b/services/applications/qcrbox_quality/quality_html/model_quality_summary.py
@@ -48,7 +48,7 @@ def basic_model_quality_indicators(cif_text: str) -> tuple[set[str], str, set[st
 
     if all(indicator.value == "N/A" for indicator in indicators):
         # If all indicators are "N/A", return empty snippets
-        return {}, "", {}
+        return set(), "", set()
 
     header_snippet = render_to_string("shared_components/mathjax_header.html", {})
 

--- a/services/applications/qcrbox_quality/quality_html/ortep.py
+++ b/services/applications/qcrbox_quality/quality_html/ortep.py
@@ -69,7 +69,7 @@ def ortep_cifvis_3d(cif_text: str) -> tuple[set[str], str, set[str]]:
     cif_model = read_cif_text_as_unified(cif_text)
     cif_block, _ = cifdata_str_or_index(cif_model, 0)
     if not check_ortep_entries_present(cif_block):
-        return {}, "", {}
+        return set(), "", set()
     cif_b64 = base64.b64encode(cif_text.encode()).decode()
 
     header_snippet = render_to_string("category_components/ortep/header.html", {})

--- a/services/applications/qcrbox_quality/quality_html/precision_plot.py
+++ b/services/applications/qcrbox_quality/quality_html/precision_plot.py
@@ -142,7 +142,7 @@ def precision_plot(cif_text: str) -> tuple[set[str], str, set[str]]:
         plot_script, plot_div = precision_vs_resolution_plot(cif_text)
     except Exception as e:
         print(f"Error generating precision plot: {e}")
-        return {}, "", {}
+        return set(), "", set()
 
     body_snippet = render_to_string("category_components/data_precision_plot/body.html", {"plot_div": plot_div})
     css_snippet = CDN.render_css()

--- a/services/applications/qcrbox_quality/quality_html/precision_plot.py
+++ b/services/applications/qcrbox_quality/quality_html/precision_plot.py
@@ -71,7 +71,7 @@ def create_precision_resolution_plot(
     xtick_pos = list(np.arange(len(values) + 1))
     d_limits = list(d_max) + [d_min[-1]]
     p.xaxis.ticker = list(xtick_pos)
-    p.xaxis.major_label_overrides = {i: f"{dlim:.2f}" for i, dlim in zip(xtick_pos, d_limits, strict=False)}
+    p.xaxis.major_label_overrides = {i: f"{dlim:.2f} Å" for i, dlim in zip(xtick_pos, d_limits, strict=False)}
     p.x_range.start = min(xtick_pos) - 0.2
     p.x_range.end = max(xtick_pos) + 0.2
 

--- a/services/applications/qcrbox_quality/quality_html/precision_summary.py
+++ b/services/applications/qcrbox_quality/quality_html/precision_summary.py
@@ -104,12 +104,12 @@ def precision_quality_indicators(cif_text: str) -> tuple[set[str], set[str], set
 
         # If no valid indicators, return empty snippets
         if not indicators:
-            return {}, "", {}
+            return set(), "", set()
 
     except Exception as e:
         # If precision analysis fails, return empty snippets
         print(f"Precision analysis failed: {e}")
-        return {}, "", {}
+        return set(), "", set()
 
     # Generate HTML components
     header_snippet = render_to_string("shared_components/mathjax_header.html", {})


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #499 


## Summary of the changes
Small bugfixes and formatting change


## How was it tested?
- manually by running a complete and incomplete cif file

## Additional considerations / follow-up work needed
see #493 

## Checklist
- [x] There is a GitHub issue describing the problem this PR is solving
- ~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
- ~~- [ ] I added automated tests for my changes~~
- ~~- [ ] I updated any relevant documentation~~
- ~~- [ ] I created separate GitHub issues for any follow-up work needed~~
