### PR TITLE
Add test docker compose file for `qcrbox_quality` container

### DIFF
--- a/services/applications/qcrbox_quality/docker-compose.qcrbox_quality.test.yml
+++ b/services/applications/qcrbox_quality/docker-compose.qcrbox_quality.test.yml
@@ -1,0 +1,44 @@
+services:
+  qcrbox_quality:
+    image: "qcrbox/qcrbox_quality:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
+    build:
+      context: services/applications/qcrbox_quality/
+      args:
+        QCRBOX_DOCKER_TAG: ${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}
+    depends_on:
+      qcrbox-registry:
+        condition: service_healthy
+    volumes:
+      - ${QCRBOX_SHARED_FILES_DIR_HOST_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_HOST_PATH}:${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}
+    networks:
+      - qcrbox-test-net
+    restart: unless-stopped
+    ports:
+      - "${QCRBOX_BIND_ADDRESS}:${QCRBOX_QUALITY_PORT:?Must set env var QUALITY_PORT}:8080"
+    environment:
+      QCRBOX_APPLICATION_DISPLAY_NAME: "Quality Display"
+      QCRBOX__NATS__HOST: "qcrbox-nats"
+      QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
+      QCRBOX__REGISTRY__SERVER__PORT: "8000"
+      QCRBOX__GUI__PORT: ${QCRBOX_QUALITY_PORT}
+    labels:
+      traefik.enable: true
+      traefik.http.routers.to-path-prefix.rule: Path(`/gui/qcrbox_quality`)
+      traefik.http.routers.to-path-prefix.middlewares: redirect-gui-path
+      traefik.http.routers.to-path-prefix.service: qcrbox_quality-service
+      traefik.http.middlewares.redirect-gui-path.redirectregex.regex: ^http://(.+)/gui/qcrbox_quality(/?)$$
+      traefik.http.middlewares.redirect-gui-path.redirectregex.replacement: http://qcrbox_quality.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
+
+      traefik.http.routers.to-subdomain.rule: HostRegexp(`^qcrbox_quality\.gui\..+$$`)
+      traefik.http.routers.to-subdomain.middlewares: redirect-gui-subdomain
+      traefik.http.routers.to-subdomain.service: qcrbox_quality-service
+      traefik.http.middlewares.redirect-gui-subdomain.redirectregex.regex: ^http://qcrbox_quality\.gui\.([^/]+)(/?)$$
+      traefik.http.middlewares.redirect-gui-subdomain.redirectregex.replacement: http://qcrbox_quality.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
+
+      traefik.http.services.qcrbox_quality-service.loadbalancer.server.scheme: http
+      traefik.http.services.qcrbox_quality-service.loadbalancer.server.port: 8080
+    logging:
+      driver: "syslog"
+      options:
+        syslog-address: udp://127.0.0.1:514
+        tag: "quality-display"


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #504 

## Summary of the changes

Adds a docker compose file which is used in the test mode of QCrBox.

## How was it tested?

By building QCrBox with the `--test-only` flag.

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~

- ~~- [ ] Example of a crossed-out item that does not apply to this PR~~
