### PR TITLE
Add restart script to devbox and repo

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -23,23 +23,28 @@
     "lesspipe":                  "latest",
     "nix-ld": {
       "version":   "latest",
-      "platforms": ["x86_64-linux"],
+      "platforms": [
+        "x86_64-linux"
+      ]
     },
     "wslu": {
       "version":   "latest",
-      "platforms": ["aarch64-linux", "x86_64-linux"],
+      "platforms": [
+        "aarch64-linux",
+        "x86_64-linux"
+      ]
     },
     "process-compose": "latest",
-    "ncurses":         "latest",
-    "jq":              "latest",
-    "nats-server":     "latest",
-    "natscli":         "latest",
-    "nats-top":        "latest",
-    "entr":            "latest",
+    "ncurses": "latest",
+    "jq": "latest",
+    "nats-server": "latest",
+    "natscli": "latest",
+    "nats-top": "latest",
+    "entr": "latest"
   },
   "env": {
     "MAMBA_ROOT_PREFIX":     "${PWD}/.devbox/virtenv/python/.conda",
-    "QCRBOX_MAMBA_ENV_PATH": "${PWD}/.devbox/virtenv/python/.conda/envs/qcrbox/",
+    "QCRBOX_MAMBA_ENV_PATH": "${PWD}/.devbox/virtenv/python/.conda/envs/qcrbox/"
   },
   "shell": {
     "init_hook": [
@@ -47,14 +52,7 @@
       "source ./scripts/devbox/initialise_shell_environment.sh",
       "uv pip install -e ./pyqcrbox[all]",
       "uv pip install -e ./qcrbox_wrapper[env-file]",
-      "test -x .git/hooks/pre-commit || pre-commit install",
-      "",
-      "#bash scripts/create_mamba_env.sh",
-      "#alias conda=micromamba",
-      "#alias sw_vers=/usr/bin/sw_vers",
-      "#eval \"$(micromamba shell hook --shell bash)\"",
-      "#micromamba activate qcrbox",
-      "#echo \"✓ Activated qcrbox mamba environment.\"",
+      "test -x .git/hooks/pre-commit || pre-commit install"
     ],
     "scripts": {
       "example-notebooks": [
@@ -64,7 +62,7 @@
         "export JUPYTERLAB_URL=$(jupyter lab list | grep 18433 | head -n1 | awk -F:: '{ print $1 }')",
         "echo \"Opening JupyterLab URL: $JUPYTERLAB_URL\"",
         "python -m webbrowser -t $JUPYTERLAB_URL",
-        "echo \"Run 'devbox services stop jupyterlab-examples' to shut down the jupyter server again.\"",
+        "echo \"Run 'devbox services stop jupyterlab-examples' to shut down the jupyter server again.\""
       ],
       "playground-notebooks": [
         "set -euo pipefail",
@@ -73,14 +71,21 @@
         "export JUPYTERLAB_URL=$(jupyter lab list | grep 18434 | head -n1 | awk -F:: '{ print $1 }')",
         "echo \"Opening JupyterLab URL: $JUPYTERLAB_URL\"",
         "python -m webbrowser -t $JUPYTERLAB_URL",
-        "echo \"Run 'devbox services stop jupyterlab-playground' to shut down the jupyter server again.\"",
+        "echo \"Run 'devbox services stop jupyterlab-playground' to shut down the jupyter server again.\""
       ],
       "qcrbox-dev-server": [
-        "watchmedo auto-restart --pattern=*.py --recursive -- pyqcrbox-run-registry-server",
+        "watchmedo auto-restart --pattern=*.py --recursive -- pyqcrbox-run-registry-server"
       ],
-      "test": [
-        "pytest -svx ./pyqcrbox/tests",
+      "test-api": [
+        "qcb up --test-only",
+        "set -a; source ./.env.test; set +a",
+        "cd ./pyqcrbox/robot_tests",
+        "sleep 5",
+        "robot api_endpoints.robot"
       ],
-    },
-  },
+      "restart-qcrbox": [
+        "bash ./scripts/restart_qcrbox.sh"
+      ]
+    }
+  }
 }

--- a/docs/how_to_guides/set_up_a_dev_environment.md
+++ b/docs/how_to_guides/set_up_a_dev_environment.md
@@ -54,6 +54,12 @@ $ qcb list components
 $ qcb list components --all
 ```
 
+You can also test that the components build and run correctly by running a Devbox script,
+
+```console exec="1" source="console"
+devbox run test-api
+```
+
 ## Build a container to test the installation
 
 Try building a component by typing:
@@ -62,6 +68,13 @@ Try building a component by typing:
 $ qcb build qcrboxtools
 ```
 
+## Restart QCrBox
+
+In the event of disaster, it is possible to destroy the containers and restart QCrBox by using a Devbox script,
+
+```console exec="1" source="console"
+devbox run restart-qcrbox
+```
 
 ## Improving File Access Speed on Windows
 

--- a/scripts/devbox/set_aliases.sh
+++ b/scripts/devbox/set_aliases.sh
@@ -1,2 +1,0 @@
-alias vi=nvim
-alias vim=nvim

--- a/scripts/restart_qcrbox.sh
+++ b/scripts/restart_qcrbox.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${DEVBOX_SHELL_ENABLED:-}" ]; then
+    echo "Error: This script must be run inside a 'devbox shell' environment."
+    echo "Please cd in /home/qcrbox/QCrBox and execute 'devbox shell' first."
+    exit 1
+fi
+
+# cd /home/qcrbox/QCrBox || {
+# 	echo "Failed to navigate into QCrBox repository"
+# 	exit 1
+# }
+
+echo "Restarting QCrBox registry and application containers"
+
+# We'll bring everything down and back up again. We'll prune
+# the containers, but keep volumes so we don't go out of sync
+# with datasets in the frontend database
+qcb down
+docker system prune -f
+qcb up --all
+
+# We'll just sleep to make sure things have started up
+sleep 10
+
+# Check that the API is functional
+if ! curl -s http://127.0.0.1:11000/api/healthz | jq -e '.status == "ok"' > /dev/null; then
+	echo "QCrBox registry is not healthy."
+	exit 1
+fi
+
+echo "QCrBox registry and application containers restarted successfully"


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #508 

## Summary of the changes

Adds a Bash script to restart the QCrBox containers by taking them down, purging the docker system and bringing the default containers back up. This script has also been added to the devbox scripts, along with a script to run the API tests.

## How was it tested?

- By running the scripts and seeing that they didn't crash

## Additional considerations / follow-up work needed

In the short term none. However, in the long term we will need to update the Bash script(s) to not expect the devbox environment.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
- [x] I updated any relevant documentation
~~- [ ] I created separate GitHub issues for any follow-up work needed~~

- ~~- [ ] Example of a crossed-out item that does not apply to this PR~~
