### PR TITLE
Pin cctbx-base to 2025.5 which is the last known version working with olex2

### DIFF
--- a/services/base_images/base_ancestor/Dockerfile
+++ b/services/base_images/base_ancestor/Dockerfile
@@ -62,7 +62,7 @@ RUN eval "$(micromamba shell hook --shell bash)" && \
     ${MAMBA_EXE} activate ${QCRBOX_MAMBA_ENV_NAME} && \
     ${MAMBA_EXE} install -y python=3.11 && \
     ${MAMBA_EXE} install -y pip setuptools wheel conda-build && \
-    ${MAMBA_EXE} install -y cctbx-base && \
+    ${MAMBA_EXE} install -y cctbx-base==2025.5 && \
     ${MAMBA_EXE} clean -y --all --force-pkgs-dirs
 
 ##


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #524 

## Summary of the changes

Pins the CCTBX version to 2025.5, which is the last known version which worked with Olex2.

## How was it tested?

- By running through the demo script for ICDM 10.

## Additional considerations / follow-up work needed

We need to pin other versions of applications, such as Olex2.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I created separate GitHub issues for any follow-up work needed