### PR TITLE
Remove support for CLI non-interactive commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 
 - We have removed the dev, docs, invoke and status options from the `qcb` CLI.
 - Removed `qcrbox-nextflow` container which was unused
+- "cli_command" is no longer a valid "implemented_as" type for non-interactive commands
 
 ### Enhancements
 

--- a/pyqcrbox/pyqcrbox/sql_models/application_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/application_spec.py
@@ -10,6 +10,7 @@ from pydantic import Field, PrivateAttr, field_validator, model_validator
 from .. import helpers
 from .base import QCrBoxPydanticBaseModel
 from .cif_entry_set import CifEntrySet
+from .command_spec.base_command_spec import ImplementedAs
 from .command_spec.command_spec import CommandSpecDiscriminatedUnion, CommandSpecWithParametersResponse
 
 __all__ = ["ApplicationSpec"]
@@ -109,6 +110,20 @@ class ApplicationSpec(ApplicationSpecBase):
         if len(command_names) != len(set(command_names)):
             raise ValueError(f"Command names must be unique, got: {command_names!r}")
         return value
+
+    @field_validator("commands")
+    @classmethod
+    def verify_implemented_as_valid(
+        cls, commands: list[CommandSpecDiscriminatedUnion]
+    ) -> list[CommandSpecDiscriminatedUnion]:
+        for command in commands:
+            if (
+                command.is_non_interactive
+                and command.implemented_as == ImplementedAs.cli_command
+                and not command.name.startswith("__")  # this is to ignore commands in the interactive lifecycle
+            ):
+                raise ValueError(f"Non-interactive command cannot be a {ImplementedAs.cli_command!r}")
+        return commands
 
     @model_validator(mode="after")
     def add_interactive_lifecycle_commands(self):

--- a/services/applications/dummy_cli/config_dummy_cli.yaml
+++ b/services/applications/dummy_cli/config_dummy_cli.yaml
@@ -42,16 +42,4 @@ commands:
         dtype: str
         description: "An unused dummy parameter"
 
-  - name: "sample_cli_cmd"
-    implemented_as: "cli_command"
-    call_pattern: "sample_cmd.sh {msg} {some_number}"
-    parameters:
-      - name: "msg"
-        dtype: str
-        default_value: null
-      - name: "some_number"
-        dtype: int
-        default_value: 42
-        required: False
-
 qcrbox_yaml_spec_version: "0.1"


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #566 

## Summary of the changes

This removes support for using CLI commands for a non-interactive command.

## How was it tested?

- Robot framework
- Pytest
- GitHub actions

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
- [x] I updated any relevant documentation
~~- [ ] I created separate GitHub issues for any follow-up work needed~~
