### PR TITLE
Validate `pyqcrbox` version between registry and application during registration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ However, there will be an initial period of stabilisation where this is not adhe
   will be returned instead of each file individually.
 - Data files now track which dataset they belong to, so deleting a data file will remove it from the dataset it is in
   similar to how deleting a dataset will delete its data files.
+- The version of `pyqcrbox` an application is based on is validated against the version the registry is built on to
+  ensure compatibility.
 
 ### Removed Features
 

--- a/pyqcrbox/pyqcrbox/cli/helpers/compose_file_config.py
+++ b/pyqcrbox/pyqcrbox/cli/helpers/compose_file_config.py
@@ -176,7 +176,6 @@ class ComposeFileConfig:
             dependencies = self.get_build_and_runtime_dependencies(service_name)
         else:
             dependencies = self.get_runtime_dependencies(service_name)
-        logger.debug(f"Getting dependencies for {service_name}: {dependencies}")
         return dependencies
 
     def get_dependency_chain(self, service_name, include_build_deps=False):

--- a/pyqcrbox/pyqcrbox/cli/helpers/compose_file_config.py
+++ b/pyqcrbox/pyqcrbox/cli/helpers/compose_file_config.py
@@ -145,7 +145,7 @@ class ComposeFileConfig:
         try:
             dockerfile = self.get_dockerfile_for_service(service_name)
             contents = dockerfile.open().readlines()
-            dependency_lines = [line for line in contents if line.startswith("FROM qcrbox")]
+            dependency_lines = [line for line in contents if line.startswith("FROM qcrbox/")]
             dependency_names = [
                 re.match("^FROM qcrbox/(?P<image_name>.*):", line).group("image_name")  # type: ignore
                 for line in dependency_lines
@@ -173,9 +173,11 @@ class ComposeFileConfig:
 
     def get_direct_dependencies(self, service_name: str, include_build_deps: bool = False):
         if include_build_deps:
-            return self.get_build_and_runtime_dependencies(service_name)
+            dependencies = self.get_build_and_runtime_dependencies(service_name)
         else:
-            return self.get_runtime_dependencies(service_name)
+            dependencies = self.get_runtime_dependencies(service_name)
+        logger.debug(f"Getting dependencies for {service_name}: {dependencies}")
+        return dependencies
 
     def get_dependency_chain(self, service_name, include_build_deps=False):
         deps_done = []

--- a/pyqcrbox/pyqcrbox/cli/subcommands/build.py
+++ b/pyqcrbox/pyqcrbox/cli/subcommands/build.py
@@ -130,6 +130,8 @@ def task_build_docker_image(service: str, docker_project: DockerProject, with_de
         if service == "base-ancestor":
             task_deps.append("task_build_python_package:pyqcrbox")
 
+    logger.debug(f"Building {service} with dependencies: {task_deps}")
+
     try:
         build_context = docker_project.get_build_context(service)
 

--- a/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
+++ b/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
@@ -19,7 +19,7 @@ from litestar.response import Redirect
 from pydantic import BaseModel
 
 from pyqcrbox import helpers, logger, msg_specs, settings
-from pyqcrbox._version import version as pyqcrbox_version
+from pyqcrbox._version import __version__ as pyqcrbox_version
 from pyqcrbox.data_management import CalculationAlreadyExistsError, DataManager
 from pyqcrbox.debug import log_eel
 from pyqcrbox.msg_specs.base import QCrBoxGenericResponse

--- a/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
+++ b/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
@@ -19,6 +19,7 @@ from litestar.response import Redirect
 from pydantic import BaseModel
 
 from pyqcrbox import helpers, logger, msg_specs, settings
+from pyqcrbox._version import version as pyqcrbox_version
 from pyqcrbox.data_management import CalculationAlreadyExistsError, DataManager
 from pyqcrbox.debug import log_eel
 from pyqcrbox.msg_specs.base import QCrBoxGenericResponse
@@ -73,7 +74,7 @@ class QCrBoxServer(QCrBoxServerClientBase):
             self.handle_command_invocation_client_response
         )
 
-    async def handle_application_registration(self, msg: msg_specs.RegisterApplication) -> None:
+    async def handle_application_registration(self, msg: msg_specs.RegisterApplication) -> QCrBoxGenericResponse:
         """Handle application registration requests.
 
         This is a handler for the `register-application` inbox in the NATS broker.
@@ -93,8 +94,29 @@ class QCrBoxServer(QCrBoxServerClientBase):
             f"Received registration for application: {msg.payload.application_spec.slug!r} "
             f"(version: {msg.payload.application_spec.version!r})"
         )
+
+        if msg.payload.application_spec.pyqcrbox_version != pyqcrbox_version:
+            error_msg = (
+                f"Registration request for {msg.payload.application_spec.slug} {msg.payload.application_spec.version}"
+                + f"rejected due to application's pyqcrbox version {msg.payload.application_spec.pyqcrbox_version} != "
+                + f"{pyqcrbox_version}"
+            )
+            logger.error(error_msg)
+            return QCrBoxGenericResponse(
+                response_to=f"{msg.payload.private_routing_key}",
+                status="failed",
+                msg=error_msg,
+            )
+
         # await self.nats_persistence_adapter.save_application_spec(msg.payload.application_spec)
         await self.sqlite_persistence_adapter.save_application_spec(msg.payload.application_spec)
+
+        return QCrBoxGenericResponse(
+            response_to=f"{msg.payload.private_routing_key}",
+            status="success",
+            msg=f"Successfully registered {msg.payload.application_spec.slug} {msg.payload.application_spec.version} "
+            + f"({msg.payload.private_routing_key})",
+        )
 
     @log_eel
     async def handle_command_invocation_by_user(self, msg: msg_specs.InvokeCommandNATS) -> QCrBoxGenericResponse:

--- a/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
+++ b/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
@@ -97,7 +97,7 @@ class QCrBoxServer(QCrBoxServerClientBase):
 
         if msg.payload.application_spec.pyqcrbox_version != pyqcrbox_version:
             error_msg = (
-                f"Registration request for {msg.payload.application_spec.slug} {msg.payload.application_spec.version}"
+                f"Registration request for {msg.payload.application_spec.slug} {msg.payload.application_spec.version} "
                 + f"rejected due to application's pyqcrbox version {msg.payload.application_spec.pyqcrbox_version} != "
                 + f"{pyqcrbox_version}"
             )

--- a/pyqcrbox/pyqcrbox/registry/shared/qcrbox_server_client_base.py
+++ b/pyqcrbox/pyqcrbox/registry/shared/qcrbox_server_client_base.py
@@ -15,6 +15,7 @@ from faststream.nats import NatsBroker
 from litestar import Litestar
 from litestar.testing import AsyncTestClient, TestClient
 
+from pyqcrbox._version import __version__ as pyqcrbox_version
 from pyqcrbox.logging import logger
 from pyqcrbox.services.persistence import NatsPersistenceAdapter, SQLitePersistenceAdapter
 from pyqcrbox.services.services_registry import QCRBOX_GLOBAL_SERVICES_REGISTRY
@@ -170,6 +171,7 @@ class QCrBoxServerClientBase(metaclass=ABCMeta):
         self.host = host or "127.0.0.1"
         self.port = port or 8000
         logger.debug(f"Running {self.clsname} with {kwargs=}")
+        logger.debug(f"pyqcrbox version: {pyqcrbox_version}")
         self._run_kwargs = kwargs
         try:
             anyio.run(self.serve)

--- a/pyqcrbox/pyqcrbox/sql_models/application_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/application_spec.py
@@ -7,7 +7,7 @@ from typing import Self
 import yaml
 from pydantic import Field, PrivateAttr, field_validator, model_validator
 
-from pyqcrbox._version import version as pyqcrbox_version
+from pyqcrbox._version import __version__ as pyqcrbox_version
 
 from .. import helpers
 from .base import QCrBoxPydanticBaseModel

--- a/pyqcrbox/pyqcrbox/sql_models/application_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/application_spec.py
@@ -7,6 +7,8 @@ from typing import Self
 import yaml
 from pydantic import Field, PrivateAttr, field_validator, model_validator
 
+from pyqcrbox._version import version as pyqcrbox_version
+
 from .. import helpers
 from .base import QCrBoxPydanticBaseModel
 from .cif_entry_set import CifEntrySet
@@ -31,6 +33,7 @@ class ApplicationSpecBase(QCrBoxPydanticBaseModel):
     name: str
     slug: str
     version: str
+    pyqcrbox_version: str = pyqcrbox_version
     description: str | None = None
     url: str | None = None
     email: str | None = None


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #580 

## Summary of the changes

The version of `pyqcrbox` is added to the ApplicationSpec (not required in the YAML), which is compared to the version in the registry. If they are different, the application registration is rejected. If they are the same, the application is registered.

## How was it tested?

- Building `dummy_cli` based on `base-application` taken from the container repository and from a local version and seeing if they were rejected by the registry or not

## Additional considerations / follow-up work needed

We can eventually add an automated test for this when the container repository has more tagged versions in it. We will also need a way to figure out when an application registration fails.   

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
- [x] I updated any relevant documentation
- [x] I created separate GitHub issues for any follow-up work needed
