### PR TITLE
Update to command parameter handling and validation

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -72,6 +72,12 @@
       ],
       "restart": [
         "bash ./scripts/restart_qcrbox.sh"
+      ],
+      "validate-apps": [
+        "bash ./scripts/validate_application_yaml.sh"
+      ],
+      "upload-containers": [
+        "bash ./update_container_repository.sh"
       ]
     }
   }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,8 @@ However, there will be an initial period of stabilisation where this is not adhe
   similar to how deleting a dataset will delete its data files.
 - The version of `pyqcrbox` an application is based on is validated against the version the registry is built on to
   ensure compatibility.
+- Validation criteria can optionally be set for command parameters, which validates a user's input for the value of a
+  parameter.
 
 ### Removed Features
 
@@ -52,6 +54,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 
 - Added how to guide on using the QCrBox Azure Container Repository.
 - Updated the how to guide on testing QCrBox.
+- Added a technical reference page on parameter specification.
 
 ## [icdm-2025]
 

--- a/docs/technical_reference/command_parameters.md
+++ b/docs/technical_reference/command_parameters.md
@@ -1,46 +1,85 @@
 # Command Parameter Specification
 
+This document details how (the) QCrBox (registry) handles parameters for commands.
+
 ## Parameter types
 
-| QCrBox Data Type       | Class                  | Description                      |
-|------------------------|------------------------|----------------------------------|
-| `str`                  | `str`                  | String type                      |
-| `int`                  | `int`                  | Integer type                     |
-| `float`                | `float`                | Floating-point number            |
-| `bool`                 | `bool`                 | Boolean value                    |
-| `QCrBox.output_cif`    | `str`                  | Path or name of output CIF file  |
-| `QCrBox.data_file`     | `DataFileParameter`    | Custom data file parameter       |
-| `QCrBox.cif_data_file` | `CifDataFileParameter` | Custom CIF data file parameter   |
+The table below lists the supported data types for parameters. The first four rows are the standard data types in
+Python, whilst the last three are custom data types for QCrBox.
 
-## Deprecated data types
+| QCrBox Data Type       | Class                  | Description                                                         |
+|------------------------|------------------------|---------------------------------------------------------------------|
+| `str`                  | `str`                  | String type                                                         |
+| `int`                  | `int`                  | Integer type                                                        |
+| `float`                | `float`                | Floating-point number                                               |
+| `bool`                 | `bool`                 | Boolean value                                                       |
+| `QCrBox.data_file`     | `DataFileParameter`    | Custom data file parameter type, used for generic files (e.g. .csv) |
+| `QCrBox.cif_data_file` | `CifDataFileParameter` | Custom CIF data file parameter typed, used for CIF files            |
+| `QCrBox.output_cif`    | `str`                  | Name to use for the output CIF file                                 |
 
-| QCrBox Data Type       | Class                  | Description                      |
-|------------------------|------------------------|----------------------------------|
-| `QCrBox.work_cif`      | `str`                  | Path or name of working CIF file |
-| `QCrBox.folder_path`   | `str`                  | Folder path                      |
-| `QCrBox.input_path`    | `str`                  | Path to input data               |
-| `QCrBox.output_path`   | `str`                  | Path to output data              |
-| `QCrBox.input_folder`  | `str`                  | Input folder path                |
+In addition to the above data types, we have the following **deprecated** data types which have been removed since
+moving to using NATS as the message broker and data store/manager. These were removed because there is no shared file
+system between containers, so the concept of input and output paths and intermediate work files are not required because
+they are not handled by users or application developers. These could come back in the future, if a use case is found.
 
-Expected attributes
+| QCrBox Data Type      | Class | Description                      |
+|-----------------------|-------|----------------------------------|
+| `QCrBox.work_cif`     | `str` | Path or name of working CIF file |
+| `QCrBox.folder_path`  | `str` | Folder path                      |
+| `QCrBox.input_path`   | `str` | Path to input data               |
+| `QCrBox.output_path`  | `str` | Path to output data              |
+| `QCrBox.input_folder` | `str` | Input folder path                |
 
-```python
-name: str
-dtype: DTypeAsStr
-description: str
+## Parameter YAML specification
+
+Parameters are defined as an array of Parameter Specifications. Each parameter requires the following fields,
+
+- `name` - the name of the parameter (must match what is used in the command implementation)
+- `dtype` - the data type of the parameter
+- `description` - a description of the parameter
+
+In addition to these three required fields, we have two optional fields
+
+- `default_value` - the default value for the parameter, used as a placeholder
+- `valid_value` - specification of the valid/allowed values for the parameter
+
+Whilst these are optional, it is strongly recommended these fields are used where appropriate. The table below shows
+which data types are compatible with both `default_value` and `valid_value`.
+
+| Data Type              | Compatible |
+|------------------------|------------|
+| `str`                  | ✅          |
+| `int`                  | ✅          |
+| `float`                | ✅          |
+| `bool`                 | ✅          |
+| `QCrBox.data_file`     | ❌          |
+| `QCrBox.cif_data_file` | ❌          |
+| `QCrBox.output_cif`    | ✅          |
+
+If `valid_value` is not set, the parameter is essentially free to be whatever is possible within the remit of the data
+type that it is. Below is an example of a YAML specification of parameters for a command.
+
+```yaml
+parameters:
+  - name: input_cif
+    dtype: QCrBox.cif_data_file
+    description: The input CIF file
+  - name: print_times
+    dtype: int
+    description: The number of times to print the CIF file
+    default_value: 2
+    valid_value:
+      numeric_range: [1, 10]
+  - name: print_mode
+    description: The mode to use to print the CIF file
+    default_value: plain
+    valid_value:
+      choices: ["colourful", "plain", "json"]
+  - name: cif_label
+    description: The CIF label/section to print, must begin with an _
+    valid_value:
+      regex: "^_"
 ```
 
-Optional attributes (default value has to be a builtin value)
 
-```python
-default_value: Any | None = None
-valid_values: ValidValueSpec | None = None
-```
-
-Valid values can be a numeric range, a list of string enums or a regex.
-
-```python
-numeric_range: tuple[float | int, float | int] | None = None
-string_enum: list[str] | None = None
-string_regex: str | None = None
-```
+All parameters are expected to have at least these three attributes.

--- a/docs/technical_reference/command_parameters.md
+++ b/docs/technical_reference/command_parameters.md
@@ -78,8 +78,11 @@ parameters:
   - name: cif_label
     description: The CIF label/section to print, must begin with an _
     valid_value:
-      regex: "^_"
+      regex: "^_"  # the value must start with a _
 ```
 
+There are three fields for specifying a valid value:
 
-All parameters are expected to have at least these three attributes.
+- `numeric_range` - a numerical range the value can be between (include of min and max), e.g. [0, 5]
+- `choices` - a list of choices a value can be, compatible only with strings
+- `regex` - a regex used to validate the value, compatible only with strings

--- a/docs/technical_reference/command_parameters.md
+++ b/docs/technical_reference/command_parameters.md
@@ -1,0 +1,46 @@
+# Command Parameter Specification
+
+## Parameter types
+
+| QCrBox Data Type       | Class                  | Description                      |
+|------------------------|------------------------|----------------------------------|
+| `str`                  | `str`                  | String type                      |
+| `int`                  | `int`                  | Integer type                     |
+| `float`                | `float`                | Floating-point number            |
+| `bool`                 | `bool`                 | Boolean value                    |
+| `QCrBox.output_cif`    | `str`                  | Path or name of output CIF file  |
+| `QCrBox.data_file`     | `DataFileParameter`    | Custom data file parameter       |
+| `QCrBox.cif_data_file` | `CifDataFileParameter` | Custom CIF data file parameter   |
+
+## Deprecated data types
+
+| QCrBox Data Type       | Class                  | Description                      |
+|------------------------|------------------------|----------------------------------|
+| `QCrBox.work_cif`      | `str`                  | Path or name of working CIF file |
+| `QCrBox.folder_path`   | `str`                  | Folder path                      |
+| `QCrBox.input_path`    | `str`                  | Path to input data               |
+| `QCrBox.output_path`   | `str`                  | Path to output data              |
+| `QCrBox.input_folder`  | `str`                  | Input folder path                |
+
+Expected attributes
+
+```python
+name: str
+dtype: DTypeAsStr
+description: str
+```
+
+Optional attributes (default value has to be a builtin value)
+
+```python
+default_value: Any | None = None
+valid_values: ValidValueSpec | None = None
+```
+
+Valid values can be a numeric range, a list of string enums or a regex.
+
+```python
+numeric_range: tuple[float | int, float | int] | None = None
+string_enum: list[str] | None = None
+string_regex: str | None = None
+```

--- a/docs/technical_reference/command_parameters.md
+++ b/docs/technical_reference/command_parameters.md
@@ -16,6 +16,7 @@ Python, whilst the last three are custom data types for QCrBox.
 | `QCrBox.data_file`     | `DataFileParameter`    | Custom data file parameter type, used for generic files (e.g. .csv) |
 | `QCrBox.cif_data_file` | `CifDataFileParameter` | Custom CIF data file parameter typed, used for CIF files            |
 | `QCrBox.output_cif`    | `str`                  | Name to use for the output CIF file                                 |
+| `QCrBox.output_path`   | `str`                  | Path to output data                                                 |
 
 In addition to the above data types, we have the following **deprecated** data types which have been removed since
 moving to using NATS as the message broker and data store/manager. These were removed because there is no shared file
@@ -27,7 +28,6 @@ they are not handled by users or application developers. These could come back i
 | `QCrBox.work_cif`     | `str` | Path or name of working CIF file |
 | `QCrBox.folder_path`  | `str` | Folder path                      |
 | `QCrBox.input_path`   | `str` | Path to input data               |
-| `QCrBox.output_path`  | `str` | Path to output data              |
 | `QCrBox.input_folder` | `str` | Input folder path                |
 
 ## Parameter YAML specification

--- a/pyqcrbox/coverage.svg
+++ b/pyqcrbox/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">25%</text>
-        <text x="80" y="14">25%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">24%</text>
+        <text x="80" y="14">24%</text>
     </g>
 </svg>

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
@@ -37,9 +37,7 @@ def _validate_arguments_against_command_parameters(cmd_spec_db: sql_models.Comma
 
     """
     params = list(cmd_spec_db.parameters.values())
-    # XXX: removed p["required"] for now as all parameters are required
-    # required_param_names = set(p["name"] for p in params if p["required"] is True)
-    required_param_names = set(p["name"] for p in params)
+    required_param_names = set(p["name"] for p in params if p["required"] is True)
     all_param_names = set(cmd_spec_db.parameters.keys())
     arg_names = set(arguments.keys())
 

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
@@ -37,7 +37,9 @@ def _validate_arguments_against_command_parameters(cmd_spec_db: sql_models.Comma
 
     """
     params = list(cmd_spec_db.parameters.values())
-    required_param_names = set(p["name"] for p in params if p["required"] is True)
+    # XXX: removed p["required"] for now as all parameters are required
+    # required_param_names = set(p["name"] for p in params if p["required"] is True)
+    required_param_names = set(p["name"] for p in params)
     all_param_names = set(cmd_spec_db.parameters.keys())
     arg_names = set(arguments.keys())
 

--- a/pyqcrbox/pyqcrbox/sql_models/__init__.py
+++ b/pyqcrbox/pyqcrbox/sql_models/__init__.py
@@ -14,4 +14,4 @@ from .command_spec import (
     InteractiveSessionSpec,
     PythonCallableSpec,
 )
-from .parameter_spec import ParameterSpec, ParameterSpecDiscriminatedUnion
+from .parameter_spec import ParameterSpecDiscriminatedUnion

--- a/pyqcrbox/pyqcrbox/sql_models/base.py
+++ b/pyqcrbox/pyqcrbox/sql_models/base.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, ConfigDict
 from sqlmodel import SQLModel
 
-__all__ = ["QCrBoxPydanticBaseModel"]
+__all__ = ["QCrBoxPydanticBaseModel", "QCrBoxBaseSQLModel"]
 
 
 class QCrBoxPydanticBaseModel(BaseModel):
@@ -9,4 +9,4 @@ class QCrBoxPydanticBaseModel(BaseModel):
 
 
 class QCrBoxBaseSQLModel(SQLModel):
-    model_config = ConfigDict(extra="forbid", use_enum_values=True)
+    model_config = ConfigDict(extra="forbid", use_enum_values=True)  # type: ignore

--- a/pyqcrbox/pyqcrbox/sql_models/command_spec/base_command_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/command_spec/base_command_spec.py
@@ -13,8 +13,44 @@ class ImplementedAs(str, Enum):
 
 
 class BaseCommandSpec(QCrBoxPydanticBaseModel):
+    """Base model specification for a command.
+
+    This is used for both non-interactive commands as well as interactive
+    commands and the commands making up the interactive lifecycle.
+
+    Attributes
+    ----------
+    name : str
+        The name of the command
+    description : str
+        A description  of the command.
+    implemented_as : ImplementedAs
+        The type of command this is, e.g. interactive_session, CLICommand or
+        PythonCallable.
+    parameters : list[ParameterSpecDiscriminatedUnion]
+        A list of parameters for the command, represented as parameter
+        specifications.
+    merge_cif_su : bool
+        Whether to merge the CIF SU or not??
+    doi : str
+        Data object identifier for this command.
+
+    Properties
+    ----------
+    is_python_callable : bool
+        Whether this command is implemented as PythonCallable.
+    is_cli_command : bool
+        Whether this command is implemented as CLICommand.
+    is_interactive : bool
+        Whether this command is an interactive session.
+    parameter_default_values : dict
+        A mapping of parameter name to the default value for that parameter.
+        This only includes non-required parameters.
+
+    """
+
     name: str
-    description: str = ""
+    description: str
     implemented_as: ImplementedAs
     parameters: list[ParameterSpecDiscriminatedUnion]
     merge_cif_su: bool = False
@@ -38,7 +74,9 @@ class BaseCommandSpec(QCrBoxPydanticBaseModel):
 
     @property
     def parameter_default_values(self):
-        return {param.name: param.default_value for param in self.parameters if not param.required}
+        # For now, we have removed this functionality as all parameters are required in a command
+        # return {param.name: param.default_value for param in self.parameters if not param.required}
+        return {}
 
     def get_parameter_by_name(self, param_name) -> ParameterSpecDiscriminatedUnion:
         # TODO: handle case where parameter is not found

--- a/pyqcrbox/pyqcrbox/sql_models/command_spec/python_callable_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/command_spec/python_callable_spec.py
@@ -17,12 +17,17 @@ class MissingTypeAnnotation(Exception):
     pass
 
 
-class ParameterValidator:
+class PythonCallableParameterValidator:
+    """Class for validating a PythonCallable parameters."""
+
     def __init__(self, fn_signature: inspect.Signature):
         self.fn_signature = fn_signature
         self.fn_params = {p.name: get_param_spec_from_signature_param(p) for p in self.fn_signature.parameters.values()}
+        logger.debug(f"PythonCallable: fn_signature {self.fn_signature}")
+        logger.debug(f"PythonCallable: fn_params {self.fn_params}")
 
     def validate(self, param_spec: dict | ParameterSpecDiscriminatedUnion):
+        """Validate a parameter against its Python callable."""
         param_spec = parameter_spec_adapter.validate_python(param_spec)
 
         if param_spec.name not in self.fn_params:
@@ -37,35 +42,32 @@ class ParameterValidator:
                 f"Parameter dtype mismatch: {param_spec.dtype!r} is not compatible with {fn_param.dtype!r}"
             )
 
-        if param_spec.required != fn_param.required:
-            raise ValueError(f"Mismatch in parameter definitions: {param_spec!r} != {fn_param!r}")
-        #
-        # if not param_spec.required and param_spec.default_value != fn_param.default_value:
-        #     raise ValueError(f"Mismatch in parameter definitions: {param_spec!r} != {fn_param!r}")
-
 
 class PythonCallableSpec(BaseCommandSpec):
-    implemented_as: Literal["python_callable"] = "python_callable"
+    """Pydantic model for specifying PythonCallable commands.
+
+    Attributes
+    ----------
+    implemented_as : str
+        The implemented as method, it being a python_callable.
+    import_path : str
+        The path to the Python source script to import, containing the callable.
+    callable_name : str
+        The name of the callable Python function. If this is not provided, it
+        is assumed to be the same as the PythonCallable command name.
+
+    """
+
+    implemented_as: Literal["python_callable"] = "python_callable"  # type: ignore
     import_path: str
     callable_name: str | None = None
 
-    # @model_validator(mode="before")
-    # def validate_parameters_against_function_signature(model_data):
-    #     # module = importlib.import_module(model_data["import_path"])
-    #     # fn = getattr(module, model_data["callable_name"])
-    #     # signature = inspect.signature(fn)
-    #     # parameters = [get_param_spec_from_signature_param(p) for p in signature.parameters.values()]
-    #     parameters = []
-    #
-    #     if "parameters" not in model_data:
-    #         model_data["parameters"] = parameters
-    #     else:
-    #         raise NotImplementedError("TODO: validate given parameters against function signature")
-    #
-    #     return model_data
-
     @model_validator(mode="after")
-    def validate_parameters_against_function_signature(model_data):
+    def validate_parameters_against_function_signature(model_data: "PythonCallableSpec") -> "PythonCallableSpec":
+        """Validate the parameters in the application spec against the callable function."""
+        if not model_data.callable_name:
+            raise ValueError("The name of the python callable function has has not been set")
+
         try:
             module = importlib.import_module(model_data.import_path)
         except ImportError as exc:
@@ -78,9 +80,8 @@ class PythonCallableSpec(BaseCommandSpec):
 
         fn = getattr(module, model_data.callable_name)
         fn_signature = inspect.signature(fn)
-        # fn_params = [get_param_spec_from_signature_param(p) for p in fn_signature.parameters.values()]
+        fn_validator = PythonCallableParameterValidator(fn_signature)
 
-        fn_validator = ParameterValidator(fn_signature)
         for p in model_data.parameters:
             try:
                 fn_validator.validate(p)
@@ -92,9 +93,7 @@ class PythonCallableSpec(BaseCommandSpec):
     @model_validator(mode="before")
     @classmethod
     def set_name_and_callable_name_if_missing(cls, model_data: dict) -> dict:
-        """
-        If `callable_name` is not explicitly provided, assume it is the same as the command name and vice versa.
-        """
+        """If `callable_name` is not explicitly provided, assume it is the same as the command name and vice versa."""
         match model_data.get("name"), model_data.get("callable_name"):
             case None, None:
                 raise ValueError("The fields 'name' and 'callable_name' cannot both be missing")
@@ -104,7 +103,6 @@ class PythonCallableSpec(BaseCommandSpec):
                 model_data["name"] = model_data["callable_name"]
             case _:
                 pass
-
         if "." in model_data["callable_name"]:
             raise ValueError("Qualified names (containing dots) are not supported yet")
 

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/__init__.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/__init__.py
@@ -1,6 +1,11 @@
 from .parameter_spec import (
-    ParameterSpec,
     ParameterSpecDiscriminatedUnion,
     get_param_spec_from_json,
     get_param_spec_from_signature_param,
 )
+
+__all__ = [
+    "ParameterSpecDiscriminatedUnion",
+    "get_param_spec_from_json",
+    "get_param_spec_from_signature_param",
+]

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -407,7 +407,7 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
 
     name: str
     dtype: DTypeAsStr
-    description: str
+    description: str = ""
     default_value: str | int | float | bool | None = None
     valid_values: ValidValueSpec | None = None
 
@@ -418,10 +418,17 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
             raise ValueError(f"Unsupported dtype: {value!r}")
         return value
 
+    # TODO: validate that default_value is a dtype compatible with the parameter
     @field_validator("default_value")
     @classmethod
     def verify_default_value_is_builtin_dtype(cls, value: Any) -> Any:
-        dtype_str = type(value).__str__
+        # Don't do anything when default_value is None -- using `is` to avoid
+        # falsey equivalents
+        if value is None:
+            return value
+        # Now we have to check to make sure the default value is a compatible
+        # data type
+        dtype_str = type(value).__name__
         if dtype_str not in _builtin_dtypes:
             supported_dtypes = list(_builtin_dtypes.keys())
             raise ValueError(

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 import nats.js.errors as nats_errors
 import svcs
-from pydantic import BeforeValidator, field_validator, model_validator
+from pydantic import BeforeValidator, Field, field_validator, model_validator
 
 from pyqcrbox.logging import logger
 
@@ -410,6 +410,20 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
     description: str = ""
     default_value: str | int | float | bool | None = None
     valid_value: ParameterValidationSpec | None = None
+
+    # We are marking all parameters as being REQUIRED and freezing the choice.
+    # If we want optional parameters later, we can change this to a required
+    # field like the above fields.
+    required: bool = Field(default_factory=lambda: True, frozen=True)
+
+    @field_validator("required")
+    @classmethod
+    def verify_parameter_is_required(cls, value: bool) -> bool:
+        """Verify that the `required` field is True."""
+        if value is not True:
+            raise ValueError("`required` field is set to False when it can only be True")
+
+        return value
 
     @field_validator("dtype")
     @classmethod

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -324,7 +324,7 @@ class ValidValueSpec(QCrBoxPydanticBaseModel):
     ----------
     numeric_range : tuple[float | int, float | int]
         The valid numeric range of the parameter (min, max), e.g. [0.0, 1.0].
-    string_enum : list[str]
+    chocies: list[str]
         A list of valid string values for the parameters, e.g. ["A", "B", "C"]
     string_regex : str
         A regex pattern to validate string input against.
@@ -332,19 +332,19 @@ class ValidValueSpec(QCrBoxPydanticBaseModel):
     """
 
     numeric_range: tuple[float | int, float | int] | None = None
-    string_enum: list[str] | None = None
-    string_regex: str | None = None
+    choices: list[str] | None = None
+    regex: str | None = None
 
     @model_validator(mode="after")
     def check_at_least_one(cls, values):
         """Check that at least one validation attribute is set."""
-        if not (values.numeric_range or values.string_enum or values.string_regex):
-            raise ValueError("At least one of numeric_range, string_enum, or string_regex must be set for validation")
+        if not (values.numeric_range or values.choices or values.regex):
+            raise ValueError("At least one of numeric_range, choices, or regex must be set for validation criteria")
         return values
 
     @field_validator("numeric_range")
     @classmethod
-    def check_range(cls, value):
+    def check_numeric_range_valid(cls, value: list[float | int] | None) -> list[float | int] | None:
         """Check if the numeric range is valid (min, max)."""
         if value and value[0] > value[1]:
             raise ValueError("Numeric value range must be (min, max)")
@@ -371,10 +371,10 @@ class ValidValueSpec(QCrBoxPydanticBaseModel):
                     return False
             except ValueError:
                 return False
-        if self.string_enum and value not in self.string_enum:
+        if self.choices and value not in self.choices:
             return False
-        if self.string_regex:  # noqa: SIM102
-            if not re.match(self.string_regex, value):
+        if self.regex:  # noqa: SIM102
+            if not re.match(self.regex, value):
                 return False
 
         return True
@@ -414,16 +414,19 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
     @field_validator("dtype")
     @classmethod
     def verify_dtype_is_a_known_type(cls, value: str) -> str:
+        """Verify that the dtype attribute is a valid choice and supported."""
         if value not in _known_dtypes:
             raise ValueError(f"Unsupported dtype: {value!r}")
         return value
 
-    # TODO: validate that default_value is a dtype compatible with the parameter
     @field_validator("default_value")
     @classmethod
-    def verify_default_value_is_builtin_dtype(cls, value: Any) -> Any:
-        # Don't do anything when default_value is None -- using `is` to avoid
-        # falsey equivalents
+    def verify_default_value_is_builtin_dtype(cls, value: Any | None) -> Any | None:
+        """Verify that the default value set is the correct dtype.
+
+        TODO : validate that default_value is a dtype compatible with the parameter
+        """
+        # using `is` to avoid falsey equivalents, such as 0
         if value is None:
             return value
         # Now we have to check to make sure the default value is a compatible
@@ -436,5 +439,38 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
             )
         return value
 
-    def dtype_is_compatible_with(self, other_dtype: str):
+    @model_validator(mode="after")
+    def verify_valid_value_correct_usage(self) -> "BaseParameterSpec":
+        """Verify that the correct validation criteria has been used for the dtype."""
+        if self.valid_values is None:
+            return self
+
+        if self.valid_values.numeric_range and self.dtype == "str":
+            raise ValueError(f"numeric_range validator is not compatible with parameter of type {self.dtype}")
+        if self.valid_values.choices and self.dtype != "str":
+            raise ValueError(f"choices validator is not compatible with parameter of type {self.dtype}")
+        if self.valid_values.regex and self.dtype != "str":
+            raise ValueError(f"regex validator is not compatible with parameter of type {self.dtype}")
+
+        return self
+
+    def dtype_is_compatible_with(self, other_dtype: type | str) -> bool:
+        """Check if this parameter is compatible with another data type.
+
+        TODO: implement more robust checking because e.g. float and int should
+              be compatible.
+
+        Parameters
+        ----------
+        other_dtype : type | str
+            The data type to check if the parameter is compatible with.
+
+        Returns
+        -------
+        bool
+            Whether or not the types are compatible.
+
+        """
+        if isinstance(other_dtype, type):
+            other_dtype = other_dtype.__name__
         return self.dtype == other_dtype

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -49,12 +49,12 @@ _builtin_dtypes = {
     "int": int,
     "float": float,
     "bool": bool,
-    # "QCrBox.input_cif": str,
     "QCrBox.output_cif": str,
+    "QCrBox.output_path": str,
+    # "QCrBox.input_cif": str,
     # "QCrBox.work_cif": str,
     # "QCrBox.folder_path": str,
     # "QCrBox.input_path": str,
-    # "QCrBox.output_path": str,
     # "QCrBox.input_folder": str,
 }
 

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -5,7 +6,6 @@ import nats.js.errors as nats_errors
 import svcs
 from pydantic import BeforeValidator, field_validator, model_validator
 
-from pyqcrbox.debug import log_eel
 from pyqcrbox.logging import logger
 
 from ..base import QCrBoxPydanticBaseModel
@@ -49,36 +49,110 @@ _builtin_dtypes = {
     "int": int,
     "float": float,
     "bool": bool,
-    "QCrBox.input_cif": str,
+    # "QCrBox.input_cif": str,
     "QCrBox.output_cif": str,
-    "QCrBox.work_cif": str,
-    "QCrBox.folder_path": str,
-    "QCrBox.input_path": str,
-    "QCrBox.output_path": str,
-    "QCrBox.input_folder": str,
+    # "QCrBox.work_cif": str,
+    # "QCrBox.folder_path": str,
+    # "QCrBox.input_path": str,
+    # "QCrBox.output_path": str,
+    # "QCrBox.input_folder": str,
 }
 
 
 class BaseParameter(QCrBoxPydanticBaseModel, ABC):
+    """Base parameter abstract class."""
+
     @abstractmethod
     async def prepare_for_execution(self, target_dir: str, target_filename: str | None = None) -> Any:
+        """Prepare a parameter for command execution.
+
+        Parameters
+        ----------
+        target_dir : str
+            The target directory to write the parameter to, if relevant.
+        target_filename : str | None
+            The target filename to write to disk, if relevant.
+
+        Returns
+        -------
+        Any
+            The value of the parameter required for command execution.
+
+        """
         pass
 
 
 class BuiltinParameter(BaseParameter):
+    """Class for handling a builtin data type parameter.
+
+    Attributes
+    ----------
+    dtype : str
+        The data type of the parameter, as a string.
+    value : Any
+        The value of the parameter.
+
+    """
+
     dtype: str
     value: Any
 
-    @log_eel
     async def prepare_for_execution(self, target_dir: str, target_filename: str | None = None) -> Any:
+        """Prepare the value for command execution.
+
+        This method essentially converts the value of the parameter into the
+        correct data type, ready to be used by the executing command.
+
+        Parameters
+        ----------
+        target_dir : str
+            Unused.
+        target_filename: str
+            Unused.
+
+        Returns
+        -------
+        Any
+            The value of the parameter as the correct data type.
+
+        """
         return _builtin_dtypes[self.dtype](self.value)
 
 
 class DataFileParameter(BaseParameter):
+    """Class for handling data file parameters, such as JSON or INP files.
+
+    Attributes
+    ----------
+    data_file_id : str
+        The QCrBox data file ID for the CIF file in the DataManager.
+
+    """
+
     data_file_id: str
 
-    @log_eel
     async def prepare_for_execution(self, target_dir: str, target_filename: str | None = None) -> str:
+        """Prepare the CIF file for command execution.
+
+        This method is used to retrieve the contents of the file from the
+        DataManager and to write it to a location on the container's file
+        system.
+
+        Parameters
+        ----------
+        target_dir : str
+            The target directory to write the file to.
+        target_filename : str | None
+            The target filename to write to disk. If not provided, the filename
+            in the DataManger wil lbe used instead.
+
+        Returns
+        -------
+        str
+            The file path (within the application container) to the file written
+            to disk.
+
+        """
         from pyqcrbox.data_management import DataManager
         from pyqcrbox.services import QCRBOX_GLOBAL_SERVICES_REGISTRY
 
@@ -100,11 +174,40 @@ class DataFileParameter(BaseParameter):
 
 
 class CifDataFileParameter(BaseParameter):
+    """Class for handling CIF datafile parameters.
+
+    Attributes
+    ----------
+    data_file_id : str
+        The QCrBox data file ID for the CIF file in the DataManager.
+
+    """
+
     data_file_id: str
     # More CIF specific parameters will go in here
 
-    @log_eel
     async def prepare_for_execution(self, target_dir: str, target_filename: str | None = None) -> str:
+        """Prepare the CIF file for command execution.
+
+        This method is used to retrieve the contents of the CIF file from the
+        DataManager and to write it to a location on the container's file
+        system.
+
+        Parameters
+        ----------
+        target_dir : str
+            The target directory to write the CIF to.
+        target_filename : str | None
+            The target filename to write to disk. If not provided, the filename
+            in the DataManger wil lbe used instead.
+
+        Returns
+        -------
+        str
+            The file path (within the application container) to the CIF file
+            written to disk.
+
+        """
         from pyqcrbox.data_management import DataManager
         from pyqcrbox.services import QCRBOX_GLOBAL_SERVICES_REGISTRY
 
@@ -134,18 +237,62 @@ _known_dtypes = _builtin_dtypes | _custom_dtypes
 
 
 def verify_dtype_is_a_known_type(v: str) -> str:
+    """Verify that a dtype string is known.
+
+    Parameters
+    ----------
+    v : str
+        The dtype to verify as a string.
+
+    Returns
+    -------
+    str
+        The input value.
+
+    """
     if v not in _known_dtypes:
         raise ValueError(f"Unsupported dtype: {v!r}")
     return v
 
 
 def parse_parameter_default_value_as_string(v: Any, dtype: type | None = None) -> BuiltinParameter:
+    """Convert a parameter's value value into a BuiltinParameter class.
+
+    Parameters
+    ----------
+    v : Any
+        The value of the default parameter.
+    dtype : type | None
+        The data type to convert to. If this is not specified, then the type
+        is inferred using Python's `type()` builtin.
+
+    Returns
+    -------
+    BuiltinParameter
+        The parameter as a BuiltinParameter spec.
+
+    """
     if not dtype or not isinstance(dtype, type):
         dtype = type(v)
     return BuiltinParameter(dtype=dtype.__name__, value=v)
 
 
 def parse_parameter_as_its_dtype(v: Any, dtype_str: str) -> Any:
+    """Convert a parameter value into its data type.
+
+    Parameters
+    ----------
+    v : Any
+        The value of the parameter.
+    dtype_str : str
+        The data type of the parameter, represented as a string.
+
+    Returns
+    -------
+    Any
+        The parameter as the specified data type.
+
+    """
     if dtype_str not in _known_dtypes:
         raise ValueError(f"Unsupported parameter type: {dtype_str}")
 
@@ -157,8 +304,7 @@ def parse_parameter_as_its_dtype(v: Any, dtype_str: str) -> Any:
         result = _known_dtypes[dtype_str](**v) if isinstance(v, dict) else _known_dtypes[dtype_str](v)
     except Exception as exc:
         logger.warning(
-            f"Could not convert value to its declared type - leaving unchanged: value={v!r}\n\n"
-            f"Original error: {exc}"
+            f"Could not convert value to its declared type - leaving unchanged: value={v!r}\n\nOriginal error: {exc}"
         )
         result = v
 
@@ -169,12 +315,101 @@ DTypeAsStr = Annotated[str, BeforeValidator(verify_dtype_is_a_known_type)]
 DefaultValueAsStr = Annotated[BuiltinParameter, BeforeValidator(parse_parameter_default_value_as_string)]
 
 
+class ValidValueSpec(QCrBoxPydanticBaseModel):
+    """Defines allowed values for a parameter.
+
+    If none of the attributes are filled in, then there will be no validation.
+
+    Attributes
+    ----------
+    numeric_range : tuple[float | int, float | int]
+        The valid numeric range of the parameter (min, max), e.g. [0.0, 1.0].
+    string_enum : list[str]
+        A list of valid string values for the parameters, e.g. ["A", "B", "C"]
+    string_regex : str
+        A regex pattern to validate string input against.
+
+    """
+
+    numeric_range: tuple[float | int, float | int] | None = None
+    string_enum: list[str] | None = None
+    string_regex: str | None = None
+
+    @model_validator(mode="after")
+    def check_at_least_one(cls, values):
+        """Check that at least one validation attribute is set."""
+        if not (values.numeric_range or values.string_enum or values.string_regex):
+            raise ValueError("At least one of numeric_range, string_enum, or string_regex must be set for validation")
+        return values
+
+    @field_validator("numeric_range")
+    @classmethod
+    def check_range(cls, value):
+        """Check if the numeric range is valid (min, max)."""
+        if value and value[0] > value[1]:
+            raise ValueError("Numeric value range must be (min, max)")
+        return value
+
+    def is_valid(self, value: str) -> bool:
+        """Check if a value is a valid choice.
+
+        Parameters
+        ----------
+        value : str
+            The value to check.
+
+        Returns
+        -------
+        bool
+            True if valid, False if not.
+
+        """
+        if self.numeric_range:
+            lo, hi = self.numeric_range
+            try:
+                if not (lo <= float(value) <= hi):
+                    return False
+            except ValueError:
+                return False
+        if self.string_enum and value not in self.string_enum:
+            return False
+        if self.string_regex:  # noqa: SIM102
+            if not re.match(self.string_regex, value):
+                return False
+
+        return True
+
+
 class BaseParameterSpec(QCrBoxPydanticBaseModel):
+    """Base dataclass for defining properties for a command parameter.
+
+    All the attributes as required when defining a parameter. The data type
+    (dtype) of the parameter is typically validated when an Application Spec
+    class is instantiated.
+
+    Attributes
+    ----------
+    name : str
+        The parameter name/label/identifier.
+    dtype : str
+        The data type of the parameter as a string, e.g. something like "bool",
+        or "QCrBox.cif_data_file".
+    description : str
+        A human-friendly description of the parameter.
+    default_value : Any | None
+        An optional default value for parameter, typically used in the frontend
+        as a placeholder.
+    valid_values : ValidValueSpec | None
+        A string representing a range of valid values for the parameter. If this
+        is not set, there will be no validation for the parameter.
+
+    """
+
     name: str
     dtype: DTypeAsStr
-    required: bool = True
-    default_value: DefaultValueAsStr | None = None
-    description: str = ""
+    description: str
+    default_value: Any | None = None
+    valid_values: ValidValueSpec | None = None
 
     @field_validator("dtype")
     @classmethod
@@ -183,18 +418,16 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
             raise ValueError(f"Unsupported dtype: {value!r}")
         return value
 
-    @model_validator(mode="before")
+    @field_validator("default_value")
     @classmethod
-    def set_field_required(cls, model_data: dict) -> dict:
-        model_data = model_data.copy()
-
-        if "default_value" not in model_data or model_data["default_value"] is None:
-            model_data["required"] = True
-            # model_data["default_value"] = SENTINEL_UNDEFINED
-        else:
-            model_data["required"] = False
-
-        return model_data
+    def verify_default_value_is_builtin_dtype(cls, value: Any) -> Any:
+        dtype_str = type(value).__str__
+        if dtype_str not in _builtin_dtypes:
+            supported_dtypes = list(_builtin_dtypes.keys())
+            raise ValueError(
+                f"Unsupported dtype {dtype_str!r} for default value. Supported values: {', '.join(supported_dtypes)}"
+            )
+        return value
 
     def dtype_is_compatible_with(self, other_dtype: str):
         return self.dtype == other_dtype

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -315,7 +315,7 @@ DTypeAsStr = Annotated[str, BeforeValidator(verify_dtype_is_a_known_type)]
 DefaultValueAsStr = Annotated[BuiltinParameter, BeforeValidator(parse_parameter_default_value_as_string)]
 
 
-class ValidValueSpec(QCrBoxPydanticBaseModel):
+class ParameterValidationSpec(QCrBoxPydanticBaseModel):
     """Defines allowed values for a parameter.
 
     If none of the attributes are filled in, then there will be no validation.
@@ -409,7 +409,7 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
     dtype: DTypeAsStr
     description: str = ""
     default_value: str | int | float | bool | None = None
-    valid_values: ValidValueSpec | None = None
+    valid_value: ParameterValidationSpec | None = None
 
     @field_validator("dtype")
     @classmethod
@@ -442,14 +442,14 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
     @model_validator(mode="after")
     def verify_valid_value_correct_usage(self) -> "BaseParameterSpec":
         """Verify that the correct validation criteria has been used for the dtype."""
-        if self.valid_values is None:
+        if self.valid_value is None:
             return self
 
-        if self.valid_values.numeric_range and self.dtype == "str":
+        if self.valid_value.numeric_range and self.dtype == "str":
             raise ValueError(f"numeric_range validator is not compatible with parameter of type {self.dtype}")
-        if self.valid_values.choices and self.dtype != "str":
+        if self.valid_value.choices and self.dtype != "str":
             raise ValueError(f"choices validator is not compatible with parameter of type {self.dtype}")
-        if self.valid_values.regex and self.dtype != "str":
+        if self.valid_value.regex and self.dtype != "str":
             raise ValueError(f"regex validator is not compatible with parameter of type {self.dtype}")
 
         return self

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -408,7 +408,7 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
     name: str
     dtype: DTypeAsStr
     description: str
-    default_value: Any | None = None
+    default_value: str | int | float | bool | None = None
     valid_values: ValidValueSpec | None = None
 
     @field_validator("dtype")

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
@@ -68,5 +68,6 @@ def get_param_spec_from_signature_param(p: inspect.Parameter) -> ParameterSpecDi
         "dtype": dtype,
         "default_value": default_value,
         "description": "dummy description which can be whatever for this validation step",
+        "required": True,
     }
     return get_param_spec_from_json(param_spec_json)

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
@@ -3,24 +3,25 @@ from typing import Annotated, Union
 
 from pydantic import Field, Tag, TypeAdapter
 
-# from .base_parameter_spec import SENTINEL_UNDEFINED
+from pyqcrbox import logger
+
 from .builtin_parameter_types import BoolParameterSpec, FloatParameterSpec, IntParameterSpec, StrParameterSpec
 from .filesystem_path_parameters import (
     CifDataFileParameterSpec,
     DataFileParameterSpec,
-    FolderPathParameterSpec,
-    GenericInputPathParameterSpec,
-    GenericOutputPathParameterSpec,
-    InputCifParameterSpec,
-    InputFolderParameterSpec,
+    # FolderPathParameterSpec,
+    # GenericInputPathParameterSpec,
+    # GenericOutputPathParameterSpec,
+    # InputCifParameterSpec,
+    # InputFolderParameterSpec,
     OutputCifParameterSpec,
-    WorkCifParameterSpec,
+    # WorkCifParameterSpec,
 )
 
 __all__ = ["ParameterSpecDiscriminatedUnion"]
 
 
-ParameterSpecTaggedUnion = Union[
+ParameterSpecTaggedUnion = Union[  # noqa: UP007
     #
     # Builtin types
     #
@@ -31,15 +32,18 @@ ParameterSpecTaggedUnion = Union[
     #
     # File/directory types with QCrBox-specific logic
     #
-    Annotated[InputCifParameterSpec, Tag("QCrBox.input_cif")],
-    Annotated[GenericInputPathParameterSpec, Tag("QCrBox.input_path")],
     Annotated[OutputCifParameterSpec, Tag("QCrBox.output_cif")],
-    Annotated[GenericOutputPathParameterSpec, Tag("QCrBox.output_path")],
-    Annotated[WorkCifParameterSpec, Tag("QCrBox.work_cif")],
-    Annotated[FolderPathParameterSpec, Tag("QCrBox.folder_path")],
     Annotated[DataFileParameterSpec, Tag("QCrBox.data_file")],
     Annotated[CifDataFileParameterSpec, Tag("QCrBox.cif_data_file")],
-    Annotated[InputFolderParameterSpec, Tag("QCrBox.input_folder")],
+    #
+    # Deprecated parameters
+    #
+    # Annotated[InputCifParameterSpec, Tag("QCrBox.input_cif")],
+    # Annotated[GenericInputPathParameterSpec, Tag("QCrBox.input_path")],
+    # Annotated[GenericOutputPathParameterSpec, Tag("QCrBox.output_path")],
+    # Annotated[WorkCifParameterSpec, Tag("QCrBox.work_cif")],
+    # Annotated[FolderPathParameterSpec, Tag("QCrBox.folder_path")],
+    # Annotated[InputFolderParameterSpec, Tag("QCrBox.input_folder")],
 ]
 ParameterSpecDiscriminatedUnion = Annotated[ParameterSpecTaggedUnion, Field(discriminator="dtype")]
 
@@ -52,7 +56,9 @@ def get_param_spec_from_json(param_spec_json: dict) -> ParameterSpecDiscriminate
 
 def get_param_spec_from_signature_param(p: inspect.Parameter) -> ParameterSpecDiscriminatedUnion:
     if p.annotation == inspect._empty:
-        return None
+        exc_msg = f"Parameter {p.name} has no annotation"
+        logger.error(exc_msg)
+        raise ValueError(exc_msg)
 
     dtype = p.annotation.__name__
     is_required = p.default == inspect._empty
@@ -64,9 +70,3 @@ def get_param_spec_from_signature_param(p: inspect.Parameter) -> ParameterSpecDi
 
 def ParameterSpec(**kwargs):
     return get_param_spec_from_json(kwargs)
-    # if isinstance(data, dict):
-    #     return get_param_spec_from_json(data)
-    # elif isinstance(data, inspect.Parameter):
-    #     return get_param_spec_from_signature_param(data)
-    # else:
-    #     raise TypeError(f"Cannot instantiate ParameterSpec from input data: {data}")

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
@@ -9,12 +9,12 @@ from .builtin_parameter_types import BoolParameterSpec, FloatParameterSpec, IntP
 from .filesystem_path_parameters import (
     CifDataFileParameterSpec,
     DataFileParameterSpec,
+    GenericOutputPathParameterSpec,
+    OutputCifParameterSpec,
     # FolderPathParameterSpec,
     # GenericInputPathParameterSpec,
-    # GenericOutputPathParameterSpec,
     # InputCifParameterSpec,
     # InputFolderParameterSpec,
-    OutputCifParameterSpec,
     # WorkCifParameterSpec,
 )
 
@@ -35,12 +35,12 @@ ParameterSpecTaggedUnion = Union[  # noqa: UP007
     Annotated[OutputCifParameterSpec, Tag("QCrBox.output_cif")],
     Annotated[DataFileParameterSpec, Tag("QCrBox.data_file")],
     Annotated[CifDataFileParameterSpec, Tag("QCrBox.cif_data_file")],
+    Annotated[GenericOutputPathParameterSpec, Tag("QCrBox.output_path")],
     #
     # Deprecated parameters
     #
     # Annotated[InputCifParameterSpec, Tag("QCrBox.input_cif")],
     # Annotated[GenericInputPathParameterSpec, Tag("QCrBox.input_path")],
-    # Annotated[GenericOutputPathParameterSpec, Tag("QCrBox.output_path")],
     # Annotated[WorkCifParameterSpec, Tag("QCrBox.work_cif")],
     # Annotated[FolderPathParameterSpec, Tag("QCrBox.folder_path")],
     # Annotated[InputFolderParameterSpec, Tag("QCrBox.input_folder")],

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/parameter_spec.py
@@ -45,8 +45,8 @@ ParameterSpecTaggedUnion = Union[  # noqa: UP007
     # Annotated[FolderPathParameterSpec, Tag("QCrBox.folder_path")],
     # Annotated[InputFolderParameterSpec, Tag("QCrBox.input_folder")],
 ]
-ParameterSpecDiscriminatedUnion = Annotated[ParameterSpecTaggedUnion, Field(discriminator="dtype")]
 
+ParameterSpecDiscriminatedUnion = Annotated[ParameterSpecTaggedUnion, Field(discriminator="dtype")]
 parameter_spec_adapter: TypeAdapter[ParameterSpecTaggedUnion] = TypeAdapter(ParameterSpecDiscriminatedUnion)
 
 
@@ -54,19 +54,19 @@ def get_param_spec_from_json(param_spec_json: dict) -> ParameterSpecDiscriminate
     return parameter_spec_adapter.validate_python(param_spec_json)
 
 
-def get_param_spec_from_signature_param(p: inspect.Parameter) -> ParameterSpecDiscriminatedUnion:
+def get_param_spec_from_signature_param(p: inspect.Parameter) -> ParameterSpecDiscriminatedUnion | None:
     if p.annotation == inspect._empty:
-        exc_msg = f"Parameter {p.name} has no annotation"
-        logger.error(exc_msg)
-        raise ValueError(exc_msg)
+        logger.error(f"Parameter {p.name} has no annotation")
+        return None
 
     dtype = p.annotation.__name__
     is_required = p.default == inspect._empty
     default_value = None if is_required else repr(p.default)
 
-    param_spec_json = {"name": p.name, "dtype": dtype, "required": is_required, "default_value": default_value}
+    param_spec_json = {
+        "name": p.name,
+        "dtype": dtype,
+        "default_value": default_value,
+        "description": "dummy description which can be whatever for this validation step",
+    }
     return get_param_spec_from_json(param_spec_json)
-
-
-def ParameterSpec(**kwargs):
-    return get_param_spec_from_json(kwargs)

--- a/scripts/update_container_repository.sh
+++ b/scripts/update_container_repository.sh
@@ -1,0 +1,32 @@
+
+# qcb down
+# docker system prune -af
+# qcb up olex2 crystal-explorer qcrboxtools qcrbox_quality
+
+az login
+az acr login --name qcrbox
+
+docker tag qcrbox/base-ancestor:latest qcrbox.azurecr.io/base-ancestor:latest
+docker tag qcrbox/base-application:latest qcrbox.azurecr.io/base-application:latest
+docker tag qcrbox/base-novnc:latest qcrbox.azurecr.io/base-novnc:latest
+docker tag qcrbox/base-wine:latest qcrbox.azurecr.io/base-wine:latest
+docker tag qcrbox/registry:latest qcrbox.azurecr.io/registry:latest
+docker tag qcrbox/olex2-linux:latest qcrbox.azurecr.io/olex2-linux:latest
+docker tag qcrbox/qcrboxtools:latest qcrbox.azurecr.io/qcrboxtools:latest
+docker tag qcrbox/crystal-explorer:latest qcrbox.azurecr.io/crystal-explorer:latest
+docker tag qcrbox/qcrbox_quality:latest qcrbox.azurecr.io/qcrbox_quality:latest
+docker tag qcrbox/cod_check:latest qcrbox.azurecr.io/cod_check:latest
+docker tag qcrbox/qcrbox_quality:latest qcrbox.azurecr.io/qcrbox_quality:latest
+docker tag qcrbox/xharpy-gpaw:latest qcrbox.azurecr.io/xharpy-gpaw:latest
+
+docker push qcrbox.azurecr.io/base-ancestor:latest
+docker push qcrbox.azurecr.io/base-application:latest
+docker push qcrbox.azurecr.io/base-novnc:latest
+docker push qcrbox.azurecr.io/base-wine:latest
+docker push qcrbox.azurecr.io/registry:latest
+docker push qcrbox.azurecr.io/olex2-linux:latest
+docker push qcrbox.azurecr.io/crystal-explorer:latest
+docker push qcrbox.azurecr.io/qcrboxtools:latest
+docker push qcrbox.azurecr.io/qcrbox_quality:latest
+docker push qcrbox.azurecr.io/cod_check:latest
+docker push qcrbox.azurecr.io/xharpy-gpaw:latest

--- a/scripts/validate_application_yaml.sh
+++ b/scripts/validate_application_yaml.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+applications=$(find -name "config_*.yaml" | grep -Ev "dummy|_template")
+failed_apps=()
+
+for app in $applications; do
+    echo "Validating: $app"
+    output=$(qcb validate "$app" 2>&1)
+    status=$?
+    if [ $status -ne 0 ]; then
+        failed_apps+=("$app"$'\n'"$output"$'\n')
+    fi
+done
+
+if [ ${#failed_apps[@]} -gt 0 ]; then
+    echo -e "\n=== Failed Applications ==="
+    for entry in "${failed_apps[@]}"; do
+        echo -e "$entry"
+        echo "----------------------------"
+    done
+else
+    echo -e "\nAll applications validated successfully."
+fi

--- a/services/applications/_template/{{cookiecutter.application_slug}}/config_{{cookiecutter.application_slug}}.yaml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/config_{{cookiecutter.application_slug}}.yaml
@@ -15,10 +15,13 @@ commands:
     parameters:
       - name: "name"
         dtype: str
+        description: "The name to print"
       - name: "duration"
         dtype: float
         default_value: 5.0
         description: "Sleep duration (in seconds)"
+        valid_value:
+          numeric_range: [0, 10]
 
   - name: "interactive_session"
     implemented_as: "interactive_session"
@@ -30,6 +33,7 @@ commands:
     interactive_lifecycle:
       run:
         implemented_as: "cli_command"
+        description: "Run command to launch the dummy GUI"
         call_pattern: "python dummy_gui.py {greeting}"
         used_basecommand_parameters: ["greeting"]
 

--- a/services/applications/cod_check/config_cod_check.yaml
+++ b/services/applications/cod_check/config_cod_check.yaml
@@ -34,6 +34,7 @@ commands:
   - name: "merge_closest_cod_entry"
     implemented_as: "python_callable"
     import_path: "configure_cod_check"
+    description: "Merge the closest COD entry into the CIF file"
     parameters:
       - name: "input_cif"
         description: "Path to the input CIF file."

--- a/services/applications/crystal_explorer/config_crystal_explorer.yaml
+++ b/services/applications/crystal_explorer/config_crystal_explorer.yaml
@@ -24,6 +24,7 @@ commands:
         implemented_as: "cli_command"
         call_pattern: "/usr/bin/CrystalExplorer --open {input_cif}"
         used_basecommand_parameters: ["input_cif"]
+        description: "Launch Crystal Explorer with the provided CIF file"
 
 cif_entry_sets:
   - name: cif_structure_ddl1

--- a/services/applications/dummy_cli/Dockerfile
+++ b/services/applications/dummy_cli/Dockerfile
@@ -8,6 +8,5 @@ COPY --chown=qcrbox:qcrbox \
      configure_dummy_cli.py \
      ${QCRBOX_HOME}
 COPY --chown=qcrbox:qcrbox --chmod=755 sample_functions.py ${QCRBOX_HOME}
-COPY --chown=qcrbox:qcrbox --chmod=755 sample_cmd.sh ${QCRBOX_HOME}/bin/
 
 ENV PATH="$PATH:${QCRBOX_HOME}/bin/"

--- a/services/applications/dummy_cli/config_dummy_cli.yaml
+++ b/services/applications/dummy_cli/config_dummy_cli.yaml
@@ -20,7 +20,7 @@ commands:
         dtype: float
         description: Sleep duration (in seconds)
         default_value: 5.0
-        valid_values:
+        valid_value:
           numeric_range: [0, 10]
 
   - name: print_cif
@@ -35,7 +35,7 @@ commands:
         dtype: int
         description: The number of times to print the CIF file
         default_value: 2
-        valid_values:
+        valid_value:
           numeric_range: [1, 10]
 
   - name: infinite_loop

--- a/services/applications/dummy_cli/config_dummy_cli.yaml
+++ b/services/applications/dummy_cli/config_dummy_cli.yaml
@@ -1,45 +1,50 @@
 #
 # Configuration for the application 'dummy_cli'
 #
-name: "Dummy CLI"
-slug: "dummy_cli"
+name: Dummy CLI
+slug: dummy_cli
 version: "0.1.0"
-description: "Dummy non-interactive application for development, testing and debugging"
+description: Dummy non-interactive application for development, testing and debugging
 url: ""
 
 commands:
-  - name: "greet_and_sleep"
-    description: "Print a greeting message, then wait for a given duration before returning."
-    implemented_as: "python_callable"
-    import_path: "pyqcrbox.helpers"
+  - name: greet_and_sleep
+    description: Print a greeting message, then wait for a given duration before returning.
+    implemented_as: python_callable
+    import_path: pyqcrbox.helpers
     parameters:
-      - name: "name"
+      - name: name
         dtype: str
-      - name: "duration"
+        description: The name of the person to be greeted
+      - name: duration
         dtype: float
+        description: Sleep duration (in seconds)
         default_value: 5.0
-        description: "Sleep duration (in seconds)"
+        valid_values:
+          numeric_range: [0, 10]
 
-  - name: "print_cif"
-    description: "A short Python function which prints the name of the input CIF and returns it back"
-    implemented_as: "python_callable"
-    import_path: "sample_functions"
+  - name: print_cif
+    description: A short Python function which prints the name of the input CIF and returns it back
+    implemented_as: python_callable
+    import_path: sample_functions
     parameters:
-      - name: "input_cif"
-        dtype: "QCrBox.cif_data_file"
-        description: "The input CIF file"
-      - name: "print_times"
-        dtype: "int"
-        default_value: "2"
-        description: "The number of times to print the CIF file"
+      - name: input_cif
+        dtype: QCrBox.cif_data_file
+        description: The input CIF file
+      - name: print_times
+        dtype: int
+        description: The number of times to print the CIF file
+        default_value: 2
+        valid_values:
+          numeric_range: [1, 10]
 
-  - name: "infinite_loop"
-    description: "A Python function which loops infinitely until cancelled"
-    implemented_as: "python_callable"
-    import_path: "sample_functions"
+  - name: infinite_loop
+    description: A Python function which loops infinitely until cancelled
+    implemented_as: python_callable
+    import_path: sample_functions
     parameters:
-      - name: "dummy"
+      - name: dummy
         dtype: str
-        description: "An unused dummy parameter"
+        description: An unused dummy parameter
 
 qcrbox_yaml_spec_version: "0.1"

--- a/services/applications/dummy_cli/sample_cmd.sh
+++ b/services/applications/dummy_cli/sample_cmd.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-echo "Hello from 'Dummy CLI' (version 0.1.0)"
-echo
-echo "This script was invoked with the following arguments: $*"

--- a/services/applications/dummy_cli/sample_functions.py
+++ b/services/applications/dummy_cli/sample_functions.py
@@ -1,7 +1,7 @@
 import time
 
 
-def print_cif(input_cif, print_times):
+def print_cif(input_cif: str, print_times: int):
     """A short running command which prints the input_cif and returns it back."""
 
     for _ in range(print_times):
@@ -10,7 +10,7 @@ def print_cif(input_cif, print_times):
     return input_cif
 
 
-def infinite_loop(dummy):
+def infinite_loop(dummy: str):
     """A command which runs forever and takes no parameters."""
 
     count = 0

--- a/services/applications/dummy_gui/config_dummy_gui.yaml
+++ b/services/applications/dummy_gui/config_dummy_gui.yaml
@@ -18,10 +18,12 @@ commands:
     interactive_lifecycle:
       run:
         implemented_as: "cli_command"
+        description: "Run command for rendering the dummy GUI"
         call_pattern: "python dummy_gui.py {input_file}"
         used_basecommand_parameters: ["input_file"]
       finalise:
         implemented_as: "python_callable"
+        description: "Finalise command for handling cleaning up afterwards"
         import_path: "dummy_gui_commands"
         callable_name: "finalise_interactive"
         used_basecommand_parameters: ["input_file"]

--- a/services/applications/mopro/config_mopro.yaml
+++ b/services/applications/mopro/config_mopro.yaml
@@ -22,22 +22,27 @@ commands:
         import_path: "configure_mopro"
         callable_name: "__run_interactive"
         used_basecommand_parameters: ["input_cif"]
+        description: "Launch MoProSuite with the provided input CIF"
       finalise:
         implemented_as: "python_callable"
         import_path: "configure_mopro"
         callable_name: "__finalise_interactive"
         used_basecommand_parameters: ["input_cif"]
+        description: "Prepare CIF to return back to QCrBox"
 
   - name: "run_inp_file"
     implemented_as: "python_callable"
     import_path: "configure_mopro"
+    description: "Run MoProSuite to process an INP file"
     parameters:
       - name: "input_cif"
         dtype: "QCrBox.cif_data_file"
         required_entry_sets: ["input"]
         merge_su: True
+        description: "Input CIF file"
       - name: "output_cif_name"
         dtype: "QCrBox.output_cif"
+        description: "Name of the output CIF"
         required_entries: []
         optional_entries: []
         required_entry_sets: ["output"]

--- a/services/applications/olex2_linux/config_olex2.yaml
+++ b/services/applications/olex2_linux/config_olex2.yaml
@@ -16,7 +16,7 @@ commands:
     parameters:
       - name: "input_file"
         dtype: "QCrBox.cif_data_file"
-        description: "Path to the CIF file to open in Olex2."
+        description: "The CIF file to open in Olex2"
         required_entry_sets: [ "cell_data", "diffraction_data" ]
         optional_entry_sets: [ "atom_data" ]
         merge_su: Yes
@@ -26,16 +26,19 @@ commands:
         implemented_as: "python_callable"
         import_path: "configure_olex2"
         callable_name: "prepare__interactive"
+        description: "Prepare the CIF file for Olex2"
         used_basecommand_parameters: ["input_file"]
       run:
         implemented_as: "cli_command"
         call_pattern: "/bin/bash /opt/olex2/start {input_file}"
         used_basecommand_parameters: ["input_file"]
+        description: "Run command for Olex2"
       finalise:
         implemented_as: "python_callable"
         import_path: "configure_olex2"
         callable_name: "finalise__interactive"
         used_basecommand_parameters: ["input_file"]
+        description: "Finalise and return the CIF file to QCrBox"
 
 cif_entry_sets:
   - name: "cell_data"

--- a/services/applications/qcrboxtools/config_qcrboxtools.yaml
+++ b/services/applications/qcrboxtools/config_qcrboxtools.yaml
@@ -97,21 +97,6 @@ commands:
           "_refln.*calc.*", "_shelx.*", "_iucr.refine_instructions_details",
           '_refine(?!_ls\.weighting|_ls\.extinction)'
         ]
-      # - name: "select_names"
-      #   dtype: str
-      #   default_value: null
-      #   required: False
-      #   description: "Comma separated list of atom names to include in the conversion"
-      # - name: "select_elements"
-      #   dtype: str
-      #   default_value: null
-      #   required: False
-      #   description: "Comma separated list of element symbols to include in the conversion"
-      # - name: "select_regexes"
-      #   dtype: str
-      #   default_value: null
-      #   required: False
-      #   description: "Comma separated list of python re regexes to match atom names against"
 
   - name: "to_unified_cif"
     implemented_as: "python_callable"
@@ -128,11 +113,6 @@ commands:
         description: "Path to save the CIF file to after converting"
         optional_entries: ["all_unified"]
         invalidated_entries: []
-      # - name: "custom_category_list"
-      #   dtype: "str"
-      #   description: "Comma separated list of custom categories (such as iucr, shelx ...) to include in the unified CIF"
-      #   default_value: None
-      #   required: False
 
 cif_entry_sets:
   - name: "molecular_structure"

--- a/services/applications/xharpy_gpaw/config_xharpy_gpaw.yaml
+++ b/services/applications/xharpy_gpaw/config_xharpy_gpaw.yaml
@@ -16,23 +16,19 @@ commands:
     parameters:
       - name: "input_cif"
         dtype: "QCrBox.cif_data_file"
-        default_value: None
         description: "Path to the CIF file containing the structure to calculate the atomic form factors for"
         required_entry_sets: ["cell", "structure", "resolution"]
         required_entries: ["_space_group_symop_operation_xyz"]
         merge_su: True
       - name: "output_tsc_name"
         dtype: str
-        default_value: None
         description: "Name to use for the output TSC file to after calculating the atomic form factors"
       - name: "functional"
         dtype: "str"
-        default_value: None
         description: "The DFT functional to use for the GPAW calculation"
       - name: "gridspacing"
         dtype: "float"
         default_value: 0.16
-        required: False
         description: "The grid spacing in Angstrom to use for the GPAW calculation"
 
   - name: "ha_refine"
@@ -42,7 +38,6 @@ commands:
     parameters:
       - name: "input_cif"
         dtype: "QCrBox.cif_data_file"
-        default_value: None
         description: "Name to use for the output CIF file containing the structure to refine"
         required_entry_sets: ["cell", "structure", "diffraction_intensities", "atomic_information"]
         optional_entry_sets: ["geometry_lookup"]
@@ -51,7 +46,6 @@ commands:
         custom_categories: ["shelx"]
       - name: "output_cif_name"
         dtype: "QCrBox.output_cif"
-        default_value: None
         description: "Path to save the CIF file to after refining the structure"
         required_entry_sets: ["structure", "atomic_information"]
         optional_entry_sets: ["geometry_lookup"]
@@ -63,12 +57,10 @@ commands:
         custom_categories: ["shelx"]
       - name: "functional"
         dtype: "str"
-        default_value: None
         description: "The DFT functional to use for the GPAW calculation"
       - name: "gridspacing"
         dtype: "float"
         default_value: 0.16
-        required: False
         description: "The grid spacing in Angstrom to use for the GPAW calculation"
 
 


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #576 

## Summary of the changes

This merges in changes to the parameter specification for commands and adds the ability to specify what a valid value is for a parameter. There is a new technical reference document which detailing the YAML specification for parameters.

## How was it tested?

- Building the container
- Robot framework
- Pytest
- GitHub actions
- QCrBox frontend tests

## Additional considerations / follow-up work needed

We have removed non-required parameters (by forcing the required field to always be set to true), meaning that if a parameter is defined for a command then a value for it must be supplied. We should discuss, after the developer release, if we want to support non-required parameters or not (Issue #589).

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
- [x] I updated any relevant documentation
- [x] I created separate GitHub issues for any follow-up work needed