### PR TITLE
Configure applications to be able to use prebuilt images

### DIFF
--- a/services/applications/cod_check/docker-compose.cod_check.prebuilt.yml
+++ b/services/applications/cod_check/docker-compose.cod_check.prebuilt.yml
@@ -1,0 +1,15 @@
+services:
+  cod_check:
+    image: "${QCRBOX_DOCKER_REPO:?Must set env var QCRBOX_DOCKER_REPO}/cod_check:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
+    environment:
+      QCRBOX__NATS__HOST: "qcrbox-nats"
+      QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
+      QCRBOX__REGISTRY__SERVER__PORT: "8000"
+    volumes:
+      - ${QCRBOX_SHARED_FILES_DIR_HOST_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_HOST_PATH}:${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}
+    depends_on:
+      qcrbox-registry:
+        condition: service_healthy
+    networks:
+      - qcrbox-net
+    restart: unless-stopped

--- a/services/applications/crystal_explorer/docker-compose.crystal-explorer.prebuilt.yml
+++ b/services/applications/crystal_explorer/docker-compose.crystal-explorer.prebuilt.yml
@@ -1,0 +1,40 @@
+services:
+  crystal-explorer:
+    image: "${QCRBOX_DOCKER_REPO:?Must set env var QCRBOX_DOCKER_REPO}/crystal-explorer:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
+    volumes:
+      - ${QCRBOX_SHARED_FILES_DIR_HOST_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_HOST_PATH}:${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}
+    networks:
+      - qcrbox-net
+    ports:
+      - "${QCRBOX_BIND_ADDRESS}:${QCRBOX_CRYSTAL_EXPLORER_PORT:?Must set env var QCRBOX_CRYSTAL_EXPLORER_PORT}:8080"
+    depends_on:
+      qcrbox-registry:
+        condition: service_healthy
+    restart: unless-stopped
+    environment:
+      QCRBOX_APPLICATION_DISPLAY_NAME: "CrystalExplorer"
+      QCRBOX__NATS__HOST: "qcrbox-nats"
+      QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
+      QCRBOX__REGISTRY__SERVER__PORT: "8000"
+      QCRBOX__GUI__PORT: ${QCRBOX_CRYSTAL_EXPLORER_PORT}
+    labels:
+      traefik.enable: true
+      traefik.http.routers.to-crystal-explorer-path-prefix.rule: Path(`/gui/crystal-explorer`)
+      traefik.http.routers.to-crystal-explorer-path-prefix.middlewares: redirect-gui-crystal-explorer-path
+      traefik.http.routers.to-crystal-explorer-path-prefix.service: crystal-explorer-service
+      traefik.http.middlewares.redirect-gui-crystal-explorer-path.redirectregex.regex: ^http://(.+)/gui/crystal-explorer(/?)$$
+      traefik.http.middlewares.redirect-gui-crystal-explorer-path.redirectregex.replacement: http://crystal-explorer.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
+
+      traefik.http.routers.to-crystal-explorer-subdomain.rule: HostRegexp(`^crystal-explorer\.gui\..+$$`)
+      traefik.http.routers.to-crystal-explorer-subdomain.middlewares: redirect-gui-crystal-explorer-subdomain
+      traefik.http.routers.to-crystal-explorer-subdomain.service: crystal-explorer-service
+      traefik.http.middlewares.redirect-gui-crystal-explorer-subdomain.redirectregex.regex: ^http://crystal-explorer\.gui\.([^/]+)(/?)$$
+      traefik.http.middlewares.redirect-gui-crystal-explorer-subdomain.redirectregex.replacement: http://crystal-explorer.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
+
+      traefik.http.services.crystal-explorer-service.loadbalancer.server.scheme: http
+      traefik.http.services.crystal-explorer-service.loadbalancer.server.port: 8080
+    logging:
+      driver: "syslog"
+      options:
+        syslog-address: udp://127.0.0.1:514
+        tag: "crystal-explorer"

--- a/services/applications/mopro/docker-compose.mopro.prebuilt.yml
+++ b/services/applications/mopro/docker-compose.mopro.prebuilt.yml
@@ -1,6 +1,6 @@
 services:
   mopro:
-    image: "qcrbox.azurecr.io/mopro:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
+    image: "${QCRBOX_DOCKER_REPO:?Must set env var QCRBOX_DOCKER_REPO}/mopro:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
     volumes:
       - ${QCRBOX_SHARED_FILES_DIR_HOST_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_HOST_PATH}:${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}
     networks:

--- a/services/applications/qcrbox_quality/docker-compose.qcrbox_quality.prebuilt.yml
+++ b/services/applications/qcrbox_quality/docker-compose.qcrbox_quality.prebuilt.yml
@@ -1,7 +1,6 @@
 services:
   qcrbox_quality:
-    image: "qcrbox/qcrbox_quality:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
-
+    image: "${QCRBOX_DOCKER_REPO:?Must set env var QCRBOX_DOCKER_REPO}/qcrbox_quality:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
     depends_on:
       qcrbox-registry:
         condition: service_healthy

--- a/services/applications/qcrboxtools/docker-compose.qcrboxtools.prebuilt.yml
+++ b/services/applications/qcrboxtools/docker-compose.qcrboxtools.prebuilt.yml
@@ -1,0 +1,20 @@
+services:
+  qcrboxtools:
+    image: "${QCRBOX_DOCKER_REPO:?Must set env var QCRBOX_DOCKER_REPO}/qcrboxtools:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
+    environment:
+      QCRBOX__NATS__HOST: "qcrbox-nats"
+      QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
+      QCRBOX__REGISTRY__SERVER__PORT: "8000"
+    volumes:
+      - ${QCRBOX_SHARED_FILES_DIR_HOST_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_HOST_PATH}:${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}
+    depends_on:
+      qcrbox-registry:
+        condition: service_healthy
+    networks:
+      - qcrbox-net
+    restart: unless-stopped
+    logging:
+      driver: "syslog"
+      options:
+        syslog-address: udp://127.0.0.1:514
+        tag: "qcrboxtools"

--- a/services/applications/xharpy_gpaw/docker-compose.xharpy-gpaw.prebuilt.yml
+++ b/services/applications/xharpy_gpaw/docker-compose.xharpy-gpaw.prebuilt.yml
@@ -1,0 +1,15 @@
+services:
+  xharpy-gpaw:
+    image: "${QCRBOX_DOCKER_REPO:?Must set env var QCRBOX_DOCKER_REPO}/xharpy-gpaw:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
+    environment:
+      QCRBOX__NATS__HOST: "qcrbox-nats"
+      QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
+      QCRBOX__REGISTRY__SERVER__PORT: "8000"
+    volumes:
+      - ${QCRBOX_SHARED_FILES_DIR_HOST_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_HOST_PATH}:${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}
+    depends_on:
+      qcrbox-registry:
+        condition: service_healthy
+    networks:
+      - qcrbox-net
+    restart: unless-stopped


### PR DESCRIPTION
## Summary of the changes

This is a hotfix change which configures the developer release applications to be able to be build as prebuilt images.

## How was it tested?

- By building the prebuilt conatiners and running the API tests
- Interacting with the applications in the frontend

## Additional considerations / follow-up work needed

N/A
