### PR TITLE
601 - remove failing and unneeded validation in cod_check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 
 ### Issues Fixed
 
+- Fixed an unneeded and failing type validation check in the COD Check example service due to parameter handling updates.
 - Fixed an issue where the `DataManager` would lose connection to the NATS server when it had too many files.
 - Replaces an obscure error message when a wrong `QCrBox.cif_data_file` or `QCrBox.data_file` parameter with a more
   helpful one.

--- a/services/applications/cod_check/configure_cod_check.py
+++ b/services/applications/cod_check/configure_cod_check.py
@@ -25,13 +25,6 @@ def parse_input(input_cif, cellpar_deviation_perc, listed_elements_only):
     # Convert cellpar_deviation to the correct type and convert the given percentage to a decimal
     cellpar_deviation = float(cellpar_deviation_perc) / 100.0
 
-    # Validate 'listed_elements_only' as a boolean value
-    if listed_elements_only.lower() not in ("true", "false"):
-        raise ValueError("'listed_elements_only' must be a boolean (true or false).")
-
-    # Convert 'listed_elements_only' to a boolean
-    listed_elements_only = listed_elements_only.lower() == "true"
-
     # Use the parent directory of the input CIF file as the working directory
     work_folder = input_cif.parent
 


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #601

## Summary of the changes

Removes a failing boolean validation check in the COD example service Python script `configure_cod_check.py`. The check is no longer required (or compatible) since the underlying command parameter handling code provides a validated boolean directly.

## How was it tested?

Tested using the currently being revised COD Check Tutorial, which rebuilds this service.

## Additional considerations / follow-up work needed


## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
