### PR TITLE
Fix issue with application templates which caused them to fail to load

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Fixed an issue where `qcb up` would use the wrong version ID for `pyqcrbox` when building service containers.
 - Fixed an issue where `qcb list` would use the wrong URL and port number for the registry API.
 - Fixed linting issues raised by `ruff` for `qcb`.
+- Fixed an issue where environment variables were unset causing applications not to launch
 - And lots more!
 
 ### Documentation

--- a/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
@@ -11,12 +11,6 @@ FROM qcrbox/INVALID-INVALID-INVALID
 
 SHELL ["/bin/bash", "-c"]
 
-ENV QCRBOX__NATS__HOST="qcrbox-nats"
-ENV QCRBOX__REGISTRY__SERVER__HOST="qcrbox-registry"
-ENV QCRBOX__REGISTRY__SERVER__PORT="8000"
-
-ENV QCRBOX_APPLICATION_DISPLAY_NAME="{{ cookiecutter.application_name }}"
-
 RUN rm -f /opt/qcrbox/.idesktop/default.lnk
 COPY --chown=qcrbox:qcrbox .idesktop/* /opt/qcrbox/.idesktop/
 COPY --chown=qcrbox:qcrbox \

--- a/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
@@ -18,7 +18,7 @@ COPY --chown=qcrbox:qcrbox \
      configure_{{ cookiecutter.application_slug }}.py \
      ${QCRBOX_HOME}
 
-COPY --chown=qcrbox:qcrbox --chmod=755 dummy_gui.py sample_cmd.sh ${QCRBOX_HOME}/bin/
+COPY --chown=qcrbox:qcrbox --chmod=755 dummy_gui.py ${QCRBOX_HOME}/bin/
 
 USER ${QCRBOX_USER}
 WORKDIR ${QCRBOX_HOME}

--- a/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.prebuilt.yml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.prebuilt.yml
@@ -5,6 +5,11 @@ services:
       context: services/applications/{{ cookiecutter.application_slug }}/
       args:
         QCRBOX_DOCKER_TAG: ${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}
+    environment:
+      QCRBOX_APPLICATION_DISPLAY_NAME: "{{ cookiecutter.application_name }}"
+      QCRBOX__NATS__HOST: "qcrbox-nats"
+      QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
+      QCRBOX__REGISTRY__SERVER__PORT: "8000"
     depends_on:
       qcrbox-registry:
         condition: service_healthy

--- a/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.run.yml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.run.yml
@@ -5,6 +5,11 @@ services:
       context: services/applications/{{ cookiecutter.application_slug }}/
       args:
         QCRBOX_DOCKER_TAG: ${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}
+    environment:
+      QCRBOX_APPLICATION_DISPLAY_NAME: "{{ cookiecutter.application_name }}"
+      QCRBOX__NATS__HOST: "qcrbox-nats"
+      QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
+      QCRBOX__REGISTRY__SERVER__PORT: "8000"
     depends_on:
       qcrbox-registry:
         condition: service_healthy

--- a/services/applications/_template/{{cookiecutter.application_slug}}/sample_cmd.sh
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/sample_cmd.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-echo "Hello from '{{ cookiecutter.application_name }}' (version {{ cookiecutter.application_version }})"
-echo
-echo "This script was invoked with the following arguments: $*"


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #610 

## Summary of the changes

The `environments` section was missing in the application template docker compose files. These variables were instead in the Dockerfile. However, in the tutorials these environment variables are removed which means an application can't connect to NATS and crash. 

## How was it tested?

- Using `qcb init` to create a new app and building it

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~