### PR TITLE
Isolate command output with temporary working directories for each command execution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,8 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Renamed `DataFileManager` to `DataManager` to better reflect that is manages more than just data files
 - Added a new tests to test the DataManager service, non-interactive commands and new API endpoints.
 - Additional fields have been added to the payload for the dataset API endpoints.
+- Inputs and outputs for commands are stored in their own temporary directories, to prevent situations where
+  input/output form previous commands would interfere. These directories are removed once a command has finished.
 - And lots more!
 
 ### Issues Fixed

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable.py
@@ -3,6 +3,7 @@ import importlib
 import inspect
 import multiprocessing.pool
 import multiprocessing.process
+import os
 import traceback
 from pathlib import Path
 from typing import Any
@@ -169,11 +170,13 @@ class PythonCallable(BaseCommand):
             calc_finished_event.set()
             calc_finished_event = None
 
-        self.pool = multiprocessing.pool.Pool(_num_processes)
-        if _cwd:
-            logger.warning(
-                "TODO: Change into working directory before executing the python callable (and switch back afterwards)!"
-            )
+        def init_working_dir():
+            if _cwd:
+                logger.debug(f"Setting working dir to _cwd {_cwd}")
+                os.chdir(_cwd)
+            logger.info(f"Executing command in directory: {os.getcwd()}")
+
+        self.pool = multiprocessing.pool.Pool(_num_processes, initializer=init_working_dir)
         param_values = {k: kwargs[k] for k in self.parameter_names if k in kwargs}
 
         pending_result = self.pool.apply_async(

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -448,10 +448,10 @@ class QCrBoxClient(QCrBoxServerClientBase):
         # and update the status of the calculation. If we don't update the status here,
         # it'll still be be marked as RUNNING in the calculation database
         logger.debug("Setting container to idle and updating calculation status after forced termination")
-        self.status.set_idle()
+        self._remove_calculation_work_dir(self.working_dir / f"{calc.calculation_id}")
         data_file_manager = await self.svcs_container.aget(DataManager)
         await data_file_manager.update_calculation_status(await calc.get_status_details())
-        self._remove_calculation_work_dir(Path(self.working_dir) / f"{calculation_id}")
+        self.status.set_idle()
 
         return msg_specs.StoppedCalculationResponse(
             calculation_id=calculation_id,
@@ -505,7 +505,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 session_id=session_id, status=CalculationStatusEnum.FAILED, output_dataset_id=None
             )
             return response
-        self._remove_calculation_work_dir(Path(self.working_dir) / f"{calc.calculation_id}")
+        self._remove_calculation_work_dir(self.working_dir / f"{calc.calculation_id}")
         self.status.set_idle()
         logger.debug("Interactive session has been closed and client set to idle")
 

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -329,6 +329,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 extra_info={"error_msg": f"Exception raised in background task: {exception!r}"},
             ),
         )
+        self._remove_calculation_work_dir(self.working_dir / f"{calculation_id}")
         self.status.set_idle()
 
     @log_eel
@@ -367,6 +368,8 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 pass
             case CLICommand():
                 pass
+
+        self._remove_calculation_work_dir(self.working_dir / f"{calculation.calculation_id}")
 
         # Set client back to being idle, otherwise it won't accept new requests
         self.status.set_idle()

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import shutil
 from pathlib import Path
 
 import anyio
@@ -31,7 +32,6 @@ class QCrBoxClient(QCrBoxServerClientBase):
         *,
         client_id: str = "anonymous_client",
         private_routing_key: str | None = None,
-        work_root_dir: Path | None = None,
         asgi_server: Litestar | None = None,
     ):
         super().__init__(asgi_server=asgi_server)
@@ -201,6 +201,16 @@ class QCrBoxClient(QCrBoxServerClientBase):
         calc = None
         data_file_manager = await self.svcs_container.aget(DataManager)
 
+        command_working_dir = self.working_dir / f"{execute_request.calculation_id}"
+        if command_working_dir.exists():
+            try:
+                shutil.rmtree(command_working_dir)
+            except Exception as exc:
+                logger.error(f"Unable to remove existing directory for calculation id at path {command_working_dir}")
+                await self.handle_command_launch_failure(execute_request.calculation_id, exc)
+                return
+        command_working_dir.mkdir(parents=True)
+
         try:
             command = ExecutableCommand(self.application_spec.get_command_spec_by_name(execute_request.command_name))
             logger.debug(f"Command to execute: {command}")
@@ -208,10 +218,10 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 await command.add_to_interactive_session_database(
                     data_file_manager, execute_request, self.private_inbox
                 )
-            parameters = await command.prepare_params(self.working_dir, execute_request.command_arguments)
+            parameters = await command.prepare_params(command_working_dir, execute_request.command_arguments)
             logger.debug(f"Executing command {command!r} in the background with arguments {parameters!r}")
             calc = await command.execute_in_background(
-                **parameters, _calculation_id=execute_request.calculation_id, _cwd=self.working_dir
+                **parameters, _calculation_id=execute_request.calculation_id, _cwd=command_working_dir
             )
             if not isinstance(calc, BaseCalculation):
                 raise RuntimeError("Command execution did not return a calculation object.")

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -139,11 +139,14 @@ class QCrBoxClient(QCrBoxServerClientBase):
             The path to the command/calculation's directory.
 
         """
+        if settings.registry.client.keep_calc_work_dir:
+            logger.info(f"Keeping calculation directory due to setting configuration: {path}")
+            return
         logger.debug(f"Removing directory {path} with contents: {os.listdir(path)}")
         shutil.rmtree(
             path, ignore_errors=True
         )  # No need to worry about errors, it will be cleaned up later if it matters
-        logger.debug(f"Removed {path}")
+        logger.debug(f"Removed calculation directory: {path}")
 
     @log_eel
     async def handle_command_invocation_request_from_server(

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -101,6 +101,50 @@ class QCrBoxClient(QCrBoxServerClientBase):
             logger.error("Application registration failed (no response from server)")
             self.shutdown()
 
+    async def _create_calculation_work_dir(self, calculation_id: str) -> Path:
+        """Create a working directory for the calculation.
+
+        The name of the directory will be the calculation ID, in the working
+        directory for the client.
+
+        Parameters
+        ----------
+        calculation_id : str
+            The ID for the calculation.
+
+        Returns
+        -------
+        Path
+            The path to the working directory for the calculation.
+
+        """
+        command_working_dir = self.working_dir / f"{calculation_id}"
+        logger.debug(f"Creating new directory {command_working_dir} for command execution")
+
+        # This should/could never happen, but you never know...
+        if command_working_dir.exists():
+            shutil.rmtree(command_working_dir)
+
+        command_working_dir.mkdir(parents=True)
+
+        return command_working_dir
+
+    @log_eel
+    def _remove_calculation_work_dir(self, path: Path) -> None:
+        """Remove the directory containing calculation output.
+
+        Parameters
+        ----------
+        path : Path
+            The path to the command/calculation's directory.
+
+        """
+        logger.debug(f"Removing directory {path} with contents: {os.listdir(path)}")
+        shutil.rmtree(
+            path, ignore_errors=True
+        )  # No need to worry about errors, it will be cleaned up later if it matters
+        logger.debug(f"Removed {path}")
+
     @log_eel
     async def handle_command_invocation_request_from_server(
         self, msg: msg_specs.CommandInvocationRequestNATS
@@ -200,16 +244,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
 
         calc = None
         data_file_manager = await self.svcs_container.aget(DataManager)
-
-        command_working_dir = self.working_dir / f"{execute_request.calculation_id}"
-        if command_working_dir.exists():
-            try:
-                shutil.rmtree(command_working_dir)
-            except Exception as exc:
-                logger.error(f"Unable to remove existing directory for calculation id at path {command_working_dir}")
-                await self.handle_command_launch_failure(execute_request.calculation_id, exc)
-                return
-        command_working_dir.mkdir(parents=True)
+        cmd_work_dir = await self._create_calculation_work_dir(execute_request.calculation_id)
 
         try:
             command = ExecutableCommand(self.application_spec.get_command_spec_by_name(execute_request.command_name))
@@ -218,10 +253,10 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 await command.add_to_interactive_session_database(
                     data_file_manager, execute_request, self.private_inbox
                 )
-            parameters = await command.prepare_params(command_working_dir, execute_request.command_arguments)
+            parameters = await command.prepare_params(cmd_work_dir, execute_request.command_arguments)
             logger.debug(f"Executing command {command!r} in the background with arguments {parameters!r}")
             calc = await command.execute_in_background(
-                **parameters, _calculation_id=execute_request.calculation_id, _cwd=command_working_dir
+                **parameters, _calculation_id=execute_request.calculation_id, _cwd=cmd_work_dir
             )
             if not isinstance(calc, BaseCalculation):
                 raise RuntimeError("Command execution did not return a calculation object.")
@@ -263,6 +298,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 logger.exception(
                     f"Failed to add output for calculation {calc.calculation_id} to DataManager due to {exc}"
                 )
+            self._remove_calculation_work_dir(cmd_work_dir)
             self.status.set_idle()
 
         logger.debug("Updating calculation status after calculation has finished")
@@ -415,6 +451,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         self.status.set_idle()
         data_file_manager = await self.svcs_container.aget(DataManager)
         await data_file_manager.update_calculation_status(await calc.get_status_details())
+        self._remove_calculation_work_dir(Path(self.working_dir) / f"{calculation_id}")
 
         return msg_specs.StoppedCalculationResponse(
             calculation_id=calculation_id,
@@ -468,6 +505,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
                 session_id=session_id, status=CalculationStatusEnum.FAILED, output_dataset_id=None
             )
             return response
+        self._remove_calculation_work_dir(Path(self.working_dir) / f"{calc.calculation_id}")
         self.status.set_idle()
         logger.debug("Interactive session has been closed and client set to idle")
 

--- a/pyqcrbox/pyqcrbox/settings.py
+++ b/pyqcrbox/pyqcrbox/settings.py
@@ -91,7 +91,7 @@ class NATSSettings(QCrBoxSettingsBaseModel):
         return f"nats://{self.host}:{self.port}/"
 
 
-class ServerAPISettings(QCrBoxSettingsBaseModel):
+class SeverSettings(QCrBoxSettingsBaseModel):
     host: str = "127.0.0.1"
     port: int = 11000
     enable_autoreload: bool = False
@@ -102,14 +102,15 @@ class ServerAPISettings(QCrBoxSettingsBaseModel):
         return f"http://{self.host}:{self.port}/api"
 
 
-class ClientAPISettings(QCrBoxSettingsBaseModel):
+class ClientSettings(QCrBoxSettingsBaseModel):
     host: str = "127.0.0.1"
     port: int = 8002
+    keep_calc_work_dir: bool = False
 
 
 class RegistrySettings(QCrBoxSettingsBaseModel):
-    server: ServerAPISettings = ServerAPISettings()
-    client: ClientAPISettings = ClientAPISettings()
+    server: SeverSettings = SeverSettings()
+    client: ClientSettings = ClientSettings()
 
 
 class TestingSettings(QCrBoxSettingsBaseModel):


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #520 

## Summary of the changes

A directory is created at the start of command execution which is where all command parameters and output should be written to. At the end of command execution, the directory is deleted therefore cleaning up after itself.

## How was it tested?

- Clicking through the user interface and looking at the state of the file system
- Robot framework
- Pytest
- GitHub actions

## Additional considerations / follow-up work needed

Unrelated, but we should also look into removing/resetting program configuration between invocations. This will only matter for interactive sessions and I suspect this is something to configure at the application level and not form part of QCrBox. Therefore I will not be creating a follow-up issue.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I updated any relevant documentation~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~
