### PR TITLE
Improvements to API message for append endpoint and fix synchronisation issues between datasets and data files 

### DIFF
--- a/pyqcrbox/pyqcrbox/data_management/data_manager.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_manager.py
@@ -70,6 +70,7 @@ class DataManager(ABC):
             A Dataset object containing metadata about the dataset.
 
         """
+        logger.debug(f"Storing dataset: {dataset.model_dump_json()}")
         await self._store_in_kv(DataManagerKeys.DATASETS, dataset.dataset_id, dataset.model_dump_json().encode())
 
     async def _store_data_file_contents(self, key: str, file_contents: bytes) -> None:
@@ -83,6 +84,7 @@ class DataManager(ABC):
             The contents of the file, as a bytes stream.
 
         """
+        logger.debug(f"Storing file contents, key = {key}")
         await self._store_in_object_store(DataManagerKeys.DATA_FILE_CONTENTS, key, file_contents)
 
     async def _store_data_file_metadata(self, data_file: DataFile) -> None:
@@ -94,6 +96,7 @@ class DataManager(ABC):
             A DataFileMetadata object containing metadata about the data file.
 
         """
+        logger.debug(f"Storing data file: {data_file.model_dump_json()}")
         await self._store_in_kv(
             DataManagerKeys.DATA_FILES, data_file.qcrbox_file_id, data_file.model_dump_json().encode()
         )
@@ -115,6 +118,7 @@ class DataManager(ABC):
             The ID of the created dataset.
 
         """
+        logger.debug(f"Creating a new dataset with data files: {data_file_ids}")
         if isinstance(data_file_ids, str):
             data_file_ids = [data_file_ids]
         data_files = [await self.get_data_file(data_file_id) for data_file_id in data_file_ids]
@@ -125,11 +129,12 @@ class DataManager(ABC):
 
         for data_file in data_files:
             data_file.qcrbox_dataset_id = dataset_id
+            logger.debug(f"Associating data file with dataset {dataset_id}: data_file = {data_file.model_dump_json()}")
             await self._store_data_file_metadata(data_file)
 
         return dataset_id
 
-    async def update_data_file_in_dataset(self, dataset_id: str, data_file_id: str) -> str:
+    async def add_data_file_to_dataset(self, dataset_id: str, data_file_id: str) -> str:
         """Append a new data file to a dataset.
 
         If the file already exists in the dataset (the file being added has the
@@ -148,6 +153,7 @@ class DataManager(ABC):
             The ID of the updated dataset.
 
         """
+        logger.debug(f"Updating data file {data_file_id} in dataset {dataset_id}")
         data_file = await self.get_data_file(data_file_id)
 
         dataset = await self.get_dataset(dataset_id)
@@ -155,6 +161,9 @@ class DataManager(ABC):
         await self._store_dataset(dataset)
 
         data_file.qcrbox_dataset_id = dataset_id
+        logger.debug(
+            f"Associating data file {data_file_id} with dataset {dataset_id}: data_file = {data_file.model_dump_json()}"
+        )
         await self._store_data_file_metadata(data_file)
 
         return dataset.dataset_id
@@ -200,12 +209,14 @@ class DataManager(ABC):
             The ID of the data file to delete.
 
         """
+        logger.debug(f"Removing data file {data_file_id}")
         data_file = await self.get_data_file(data_file_id)
 
         await self._delete_from_kv(DataManagerKeys.DATA_FILES, data_file_id)
         await self._delete_from_object_store(DataManagerKeys.DATA_FILE_CONTENTS, data_file_id)
 
         if data_file.qcrbox_dataset_id:
+            logger.debug(f"Removing data file {data_file_id} from parent dataset {data_file.qcrbox_dataset_id}")
             parent_dataset = await self.get_dataset(data_file.qcrbox_dataset_id)
             parent_dataset.data_files.pop(data_file.filename)
             await self._store_dataset(parent_dataset)
@@ -225,7 +236,7 @@ class DataManager(ABC):
             logger.error(f"No dataset found for id {dataset_id!r}")
             raise
         dataset = Dataset.model_validate_json(dataset_as_bytes.decode())
-        logger.debug(f"Removing dataset id={dataset_id!r} and data files {list(dataset.data_files.keys())}")
+        logger.debug(f"Removing dataset {dataset_id} and data files {list(dataset.data_files.keys())}")
 
         for _, file_metadata in dataset.data_files.items():
             await self.delete_data_file(file_metadata.qcrbox_file_id)

--- a/pyqcrbox/pyqcrbox/data_management/data_manager.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_manager.py
@@ -122,15 +122,15 @@ class DataManager(ABC):
         if isinstance(data_file_ids, str):
             data_file_ids = [data_file_ids]
         data_files = [await self.get_data_file(data_file_id) for data_file_id in data_file_ids]
-
         dataset_id = generate_dataset_id()
-        dataset_info = Dataset(dataset_id=dataset_id, data_files={f.filename: f for f in data_files})
-        await self._store_dataset(dataset_info)
 
         for data_file in data_files:
             data_file.qcrbox_dataset_id = dataset_id
             logger.debug(f"Associating data file with dataset {dataset_id}: data_file = {data_file.model_dump_json()}")
             await self._store_data_file_metadata(data_file)
+
+        dataset_info = Dataset(dataset_id=dataset_id, data_files={f.filename: f for f in data_files})
+        await self._store_dataset(dataset_info)
 
         return dataset_id
 
@@ -155,15 +155,14 @@ class DataManager(ABC):
         """
         logger.debug(f"Updating data file {data_file_id} in dataset {dataset_id}")
         data_file = await self.get_data_file(data_file_id)
-
         dataset = await self.get_dataset(dataset_id)
-        dataset.data_files[data_file.filename] = data_file
-        await self._store_dataset(dataset)
 
         data_file.qcrbox_dataset_id = dataset_id
         logger.debug(
             f"Associating data file {data_file_id} with dataset {dataset_id}: data_file = {data_file.model_dump_json()}"
         )
+        dataset.data_files[data_file.filename] = data_file
+        await self._store_dataset(dataset)
         await self._store_data_file_metadata(data_file)
 
         return dataset.dataset_id
@@ -293,8 +292,10 @@ class DataManager(ABC):
 
         """
         metadata_as_bytes = await self._retrieve_from_kv(DataManagerKeys.DATA_FILES, data_file_id)
+        data_file = DataFile.model_validate_json(metadata_as_bytes.decode())
+        logger.debug(f"Retrieved data file: {data_file.model_dump_json()}")
 
-        return DataFile.model_validate_json(metadata_as_bytes.decode())
+        return data_file
 
     async def get_data_files(self) -> list[DataFile]:
         """Get the metadata for all the data files.
@@ -330,7 +331,10 @@ class DataManager(ABC):
             exc_msg = f"Dataset not found: {dataset_id!r}"
             raise DatasetNotFoundError(exc_msg) from exc
 
-        return Dataset.model_validate_json(dataset_info_as_bytes.decode())
+        dataset = Dataset.model_validate_json(dataset_info_as_bytes.decode())
+        logger.debug(f"Retrieved dataset: {dataset.model_dump_json()}")
+
+        return dataset
 
     async def get_datasets(self) -> list[Dataset]:
         """Get metadata for each dataset in the data manager.

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -506,7 +506,7 @@ async def append_to_dataset(
     return QCrBoxResponse(
         content={
             "status": "success",
-            "message": f"Appended data file {appended_file.qcrbox_file_id} to dataset {dataset_id!r}",
+            "message": f"Appended data file {appended_file.qcrbox_file_id!r} to dataset {dataset_id!r}",
             "payload": {
                 "datasets": [dataset],
                 "data_files": list(dataset.data_files.values()),

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -502,14 +502,15 @@ async def append_to_dataset(
     """Append a new data file to a dataset."""
     dataset_id = await api_helpers.append_to_dataset(id, data, data_manager=data_manager)
     dataset = await api_helpers.get_dataset_info(dataset_id, data_manager=data_manager)
+    appended_file = dataset.data_files[data.filename]
     return QCrBoxResponse(
         content={
             "status": "success",
-            "message": f"Appended file to dataset: {dataset_id!r}",
+            "message": f"Appended data file {appended_file.qcrbox_file_id} to dataset {dataset_id!r}",
             "payload": {
                 "datasets": [dataset],
                 "data_files": list(dataset.data_files.values()),
-                "appended_file": dataset.data_files[data.filename],
+                "appended_file": appended_file,
             },
         },
         status_code=201,

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_helpers.py
@@ -458,7 +458,7 @@ async def append_to_dataset(
 
     """
     qcrbox_data_file_id = await import_data_file(data, data_manager=data_manager)
-    qcrbox_dataset_id = await data_manager.update_data_file_in_dataset(dataset_id, qcrbox_data_file_id)
+    qcrbox_dataset_id = await data_manager.add_data_file_to_dataset(dataset_id, qcrbox_data_file_id)
 
     return qcrbox_dataset_id
 

--- a/pyqcrbox/tests/test_data_manager.py
+++ b/pyqcrbox/tests/test_data_manager.py
@@ -100,7 +100,7 @@ async def test_appending_to_dataset(data_manager: DataManager, sample_cif_file: 
     )
 
     # Now append another file and check it's in there too
-    appended_dataset_id = await data_manager.update_data_file_in_dataset(dataset_id, data_file_id_2)
+    appended_dataset_id = await data_manager.add_data_file_to_dataset(dataset_id, data_file_id_2)
     assert appended_dataset_id == dataset_id, (
         "Dataset ID returned for appended dataset doesn't match original dataset ID"
     )


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #617 

## Summary of the changes

This updates the message in the API endpoint which appends a data file to a dataset. The message now contains both the data file and dataset IDs, with less ambiguous wording.

Logging has also been improved for file and dataset management, which should help us diagnose issues related to the code sequence when using the data management APIs.

## How was it tested?

- Robot framework
- Pytest
- GitHub actions

## Additional considerations / follow-up work needed

We should improve the messages of the other endpoints. 

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I created separate GitHub issues for any follow-up work needed
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~