### PR TITLE
Change CLI term to "Non-interactive Command" in `qcb init`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,9 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Additional fields have been added to the payload for the dataset API endpoints.
 - Inputs and outputs for commands are stored in their own temporary directories, to prevent situations where
   input/output form previous commands would interfere. These directories are removed once a command has finished.
+- The application types in `qcb init` have been given more descriptive names: "CLI" -> "Non-interactive Command" and
+  "GUI (Linux)" -> "Interactive GUI (Linux)". We have also reintroduced the "Interactive GUI (Windows)" application
+  which lets you build an interactive application based on a Windows application running via Wine.
 - And lots more!
 
 ### Issues Fixed

--- a/docs/tutorials/wrap_python_command.md
+++ b/docs/tutorials/wrap_python_command.md
@@ -31,9 +31,10 @@ Please provide some basic information about your application.
 The following dialog will guide you through the relevant settings.
 
   [1/7] Select application_type
-    1 - CLI
-    2 - GUI (Linux)
-    Choose from [1/2] (1): 1
+    1 - Non-interactive Command
+    2 - Interactive GUI (Linux)
+    3 - Interactive GUI (Windows)
+    Choose from [1/2/3] (1):
   [2/7] application_slug (cod_check_tutorial):
   [3/7] application_name (Cod Check): COD Check Tutorial
   [4/7] application_version (x.y.z): 0.0.1

--- a/services/applications/_template/cookiecutter.json
+++ b/services/applications/_template/cookiecutter.json
@@ -1,5 +1,9 @@
 {
-  "application_type": ["CLI", "GUI (Linux)"],
+  "application_type": [
+    "Non-interactive Command",
+    "Interactive GUI (Linux)",
+    "Interactive GUI (Windows)"
+  ],
   "application_slug": "<will_be_provided_by_run_cookiecutter>",
   "application_name": "{{ cookiecutter.application_slug.replace('_', ' ').title() }}",
   "application_version": "x.y.z",

--- a/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
@@ -1,9 +1,9 @@
 ARG QCRBOX_DOCKER_TAG
-{% if cookiecutter.application_type == "CLI" %}
+{% if cookiecutter.application_type == "Non-interactive Command" %}
 FROM qcrbox/base-application:${QCRBOX_DOCKER_TAG}
-{% elif cookiecutter.application_type == "GUI (Linux)" %}
+{% elif cookiecutter.application_type == "Interactive GUI (Linux)" %}
 FROM qcrbox/base-novnc:${QCRBOX_DOCKER_TAG}
-{% elif cookiecutter.application_type == "GUI (Windows)" %}
+{% elif cookiecutter.application_type == "Interactive GUI (Windows)" %}
 FROM qcrbox/base-wine:${QCRBOX_DOCKER_TAG}
 {% else %}
 FROM qcrbox/INVALID-INVALID-INVALID


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #600 

## Summary of the changes

A small change to the terminology to the command types in `qcb init`. We have changed "CLI" to "Non-interactive Command" to make it clearer what it actually is. At the same time, we updated the "GUI (Linux)" name to "Interactive GUI (Linux)" and added "Interactive GUI (Windows)", the wine container, back as an option.

## How was it tested?

- Running `qcb init` and creating a test application for each type 

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
- [x] I updated any relevant documentation
~~- [ ] I added automated tests for my changes~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~