### PR TITLE
Add two new tests command into dummy CLI

### DIFF
--- a/services/applications/dummy_cli/config_dummy_cli.yaml
+++ b/services/applications/dummy_cli/config_dummy_cli.yaml
@@ -47,4 +47,40 @@ commands:
         dtype: str
         description: An unused dummy parameter
 
+  - name: change_cif_name
+    description: A Python function which changes the file name of a CIF
+    implemented_as: python_callable
+    import_path: sample_functions
+    parameters:
+      - name: input_cif
+        dtype: QCrBox.cif_data_file
+        description: The main CIF
+        required_entry_sets: [ "cell_elements" ]
+      - name: output_cif_name
+        dtype: str
+        description: The name of the output CIF file
+        # required_entry_sets: [ "cell_elements" ]
+        # invalidated_entries: [ ]
+
+  - name: print_two_cif
+    description: A Python function which prints the contents of two CIF files
+    implemented_as: python_callable
+    import_path: sample_functions
+    parameters:
+      - name: cif1
+        dtype: QCrBox.cif_data_file
+        description: The first CIF file
+      # Note that we can only have ONE cif_data_file, other CIFs have to be data_files
+      - name: cif2
+        dtype: QCrBox.data_file
+        description: The second CIF file
+        # required_entry_sets: [ "cell_elements" ]
+
+cif_entry_sets:
+  - name: "cell_elements"
+    required: [
+      "_cell_length_a", "_cell_length_b", "_cell_length_c", "_cell_angle_alpha",
+      "_cell_angle_beta", "_cell_angle_gamma", "_chemical_formula_sum"
+    ]
+
 qcrbox_yaml_spec_version: "0.1"

--- a/services/applications/dummy_cli/sample_functions.py
+++ b/services/applications/dummy_cli/sample_functions.py
@@ -1,4 +1,6 @@
+import shutil
 import time
+from pathlib import Path
 
 
 def print_cif(input_cif: str, print_times: int):
@@ -19,3 +21,28 @@ def infinite_loop(dummy: str):
         count += 1
         print(f"{count = }")
         time.sleep(2)
+
+
+def change_cif_name(input_cif: str, output_cif_name: str):
+    """Change the name of the output CIF."""
+
+    input_cif_path = Path(input_cif)
+    output_cif_path = input_cif_path.parent / output_cif_name
+    output_cif_path = output_cif_path.with_suffix(".cif")
+    shutil.copy(input_cif_path, output_cif_path)
+
+    return str(output_cif_path)
+
+
+def print_two_cif(cif1: str, cif2: str):
+    """A command to print the contents of cif1 and cif2."""
+
+    def _print(fp):
+        print(fp)
+        with open(fp, "r") as file:
+            print(file.readlines())
+
+    _print(cif1)
+    _print(cif2)
+
+    return cif2


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #623 

## Summary of the changes

Adds two new non-interactive commands to Dummy CLI:

- change_cif_name: a test case for using an input to change the output name (e.g. mimics some commands in Mopro which have an output path parameter)
- print_two_cif: a test case for uploading an additional CIF/data file and it being appended to the original dataset

## How was it tested?

- Testing the commands in the frontend

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added automated tests for my changes~~
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~