### PR TITLE
Bug fix for output cif names not being set correctly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Fixed an issue where the `base-ancestor` image wouldn't build because `conda` couldn't resolve the environment
   dependencies.
 - Fixed an issue where environment variables were unset causing applications not to launch
+- Fixed an issue where the output cif parameter was not being used correctly
 - And lots more!
 
 ### Documentation

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -234,6 +234,7 @@ class CifDataFileParameter(QCrBoxPydanticBaseModel):
         if not input_cif_path.exists():
             raise OSError("CIF has not yet been exported to disk")
         output_cif_path = input_cif_path.parent / f"{input_cif_path.stem}-converted.cif"
+        self._exported_file_path = input_cif_path
 
         try:
             logger.debug(f"Converting CIF to specific format with parameters: {transform_options}")
@@ -252,7 +253,9 @@ class CifDataFileParameter(QCrBoxPydanticBaseModel):
         except (BaseException, Exception) as exc:  # QCrBoxTools uses BaseException as the exception subclass
             logger.error(f"Unable to translate {transform_options.parameter_name} due to exception: {exc}")
 
-        return str(input_cif_path)
+        logger.debug(f"Returning {self._exported_file_path} from CifDataFileParameter.to_specific_format()")
+
+        return str(self._exported_file_path)
 
     @log_eel
     async def to_unified_format(self, new_cif_path: str, merge_options: Cif2CifOptions) -> str:
@@ -274,6 +277,7 @@ class CifDataFileParameter(QCrBoxPydanticBaseModel):
 
         original_cif_path = Path(self._exported_file_path)
         merge_cif_path = original_cif_path.parent / f"{original_cif_path.stem}-unified.cif"
+        self._exported_file_path = new_cif_path
         logger.debug(f"Merging {original_cif_path} and {new_cif_path} together at {merge_cif_path}: {merge_options}")
 
         try:
@@ -287,13 +291,15 @@ class CifDataFileParameter(QCrBoxPydanticBaseModel):
             )
             logger.debug(f"CIFs merged successfully into file {merge_cif_path=}")
             shutil.copy(merge_cif_path, new_cif_path)
-            self._exported_file_path = str(merge_cif_path)
+            self._exported_file_path = str(new_cif_path)
         except NoKeywordsError as exc:
             logger.warning(f"{merge_options.parameter_name} has no required or optional CIF entries defined: {exc}")
         except (BaseException, Exception) as exc:
             logger.error(
                 f"There was a problem merging {self._exported_file_path} using {merge_options} due to exception: {exc}"
             )
+
+        logger.debug(f"Returning {self._exported_file_path} from CifDataFileParameter.to_unified_format()")
 
         return str(self._exported_file_path)
 


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #628

## Summary of the changes

This fixes an issue related to CIF name not being set correctly if there is a merge/translation issue.

## How was it tested?

- Robot framework
- GitHub actions
- Using the Dummy CLI application in the front end

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~