### PR TITLE
Use `BaseParameter` as base class for `CifDataFileParameter`

### DIFF
--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/base_command.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/base_command.py
@@ -49,9 +49,7 @@ class BaseCommand(metaclass=ABCMeta):
     # The fact that a parsed parameter can be BaseParameter or CifDataFileParameter
     # is unsatisfying and warrants changing
 
-    def _parse_params_into_dtype(
-        self, command_arguments: dict[str, str]
-    ) -> dict[str, BaseParameter | CifDataFileParameter]:
+    def _parse_params_into_dtype(self, command_arguments: dict[str, str]) -> dict[str, BaseParameter]:
         """Convert a command arguments into a BaseParameter derived classes.
 
         Create a mapping of the parameters, where each item in the output
@@ -89,7 +87,7 @@ class BaseCommand(metaclass=ABCMeta):
 
     async def _prepare_params_for_execution(
         self,
-        parsed_params: dict[str, BaseParameter | CifDataFileParameter],
+        parsed_params: dict[str, BaseParameter],
         application_spec: ApplicationSpec,
         working_dir: str,
     ) -> dict[str, Any]:
@@ -101,7 +99,7 @@ class BaseCommand(metaclass=ABCMeta):
 
         Parameters
         ----------
-        parsed_params : dict[str, BaseParameter | CifDataFileParameter]
+        parsed_params : dict[str, BaseParameter]
             A mapping of argument/parameter name to a BaseParameter derived
             class which is used for command execution.
         application_spec : ApplicationSpec
@@ -145,7 +143,7 @@ class BaseCommand(metaclass=ABCMeta):
         application_spec: ApplicationSpec,
         command_arguments: dict[str, str],
         working_dir: str | Path,
-    ) -> tuple[dict[str, BaseParameter | CifDataFileParameter], dict[str, Any]]:
+    ) -> tuple[dict[str, BaseParameter], dict[str, Any]]:
         """Prepare the parameters required for command execution.
 
         If there are optional arguments for the command which are not included
@@ -166,7 +164,7 @@ class BaseCommand(metaclass=ABCMeta):
 
         Returns
         -------
-        dict[str, BaseParameter | CifDataFileParameter]
+        dict[str, BaseParameter]
             A mapping of argument/parameter name to a BaseParameter derived
             class which is used for command execution.
         dict[str, Any]

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/cli_command.py
@@ -10,7 +10,7 @@ import anyio
 from pyqcrbox import logger
 from pyqcrbox.sql_models import CLICommandSpec
 from pyqcrbox.sql_models.application_spec import ApplicationSpec
-from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import BaseParameter, CifDataFileParameter
+from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import BaseParameter
 
 from .base_command import BaseCommand
 from .cli_command_calculation import CLICmdCalculation
@@ -73,7 +73,7 @@ class CLICommand(BaseCommand):
         application_spec: ApplicationSpec,
         command_arguments: dict[str, str],
         working_dir: str | Path,
-    ) -> tuple[dict[str, BaseParameter | CifDataFileParameter], dict[str, Any]]:
+    ) -> tuple[dict[str, BaseParameter], dict[str, Any]]:
         """Prepare the parameters required for command execution.
 
         If there are optional arguments for the command which are not included
@@ -94,7 +94,7 @@ class CLICommand(BaseCommand):
 
         Returns
         -------
-        dict[str, BaseParameter | CifDataFileParameter]
+        dict[str, BaseParameter]
             A mapping of argument/parameter name to a BaseParameter derived
             class which is used for command execution.
         dict[str, Any]

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session.py
@@ -14,7 +14,7 @@ from pyqcrbox.registry.client.executable_command.python_callable import PythonCa
 from pyqcrbox.sql_models import InteractiveSessionSpec
 from pyqcrbox.sql_models.application_spec import ApplicationSpec
 from pyqcrbox.sql_models.interactive_session_info import InteractiveSessionInfo
-from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import BaseParameter, CifDataFileParameter
+from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import BaseParameter
 
 from .interactive_session_calculation import InteractiveSessionCalculation
 
@@ -177,7 +177,7 @@ class InteractiveSession(BaseCommand):
         application_spec: ApplicationSpec,
         command_arguments: dict[str, str],
         working_dir: str | Path,
-    ) -> tuple[dict[str, BaseParameter | CifDataFileParameter], dict[str, Any]]:
+    ) -> tuple[dict[str, BaseParameter], dict[str, Any]]:
         """Prepare the parameters required for command execution.
 
         If there are optional arguments for the command which are not included
@@ -198,7 +198,7 @@ class InteractiveSession(BaseCommand):
 
         Returns
         -------
-        dict[str, BaseParameter | CifDataFileParameter]
+        dict[str, BaseParameter]
             A mapping of argument/parameter name to a BaseParameter derived
             class which is used for command execution.
         dict[str, Any]

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable.py
@@ -15,7 +15,7 @@ from pyqcrbox import logger
 from pyqcrbox.debug import log_eel
 from pyqcrbox.sql_models import PythonCallableSpec
 from pyqcrbox.sql_models.application_spec import ApplicationSpec
-from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import BaseParameter, CifDataFileParameter
+from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import BaseParameter
 
 from . import BaseCommand
 from .python_callable_calculation import PythonCallableCalculation
@@ -91,7 +91,7 @@ class PythonCallable(BaseCommand):
         application_spec: ApplicationSpec,
         command_arguments: dict[str, str],
         working_dir: str | Path,
-    ) -> tuple[dict[str, BaseParameter | CifDataFileParameter], dict[str, Any]]:
+    ) -> tuple[dict[str, BaseParameter], dict[str, Any]]:
         """Prepare the parameters required for command execution.
 
         If there are optional arguments for the command which are not included
@@ -112,7 +112,7 @@ class PythonCallable(BaseCommand):
 
         Returns
         -------
-        dict[str, BaseParameter | CifDataFileParameter]
+        dict[str, BaseParameter]
             A mapping of argument/parameter name to a BaseParameter derived
             class which is used for command execution.
         dict[str, Any]

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -19,7 +19,6 @@ from pyqcrbox.sql_models import CalculationStatusDetails, CalculationStatusEnum
 from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import (
     BaseParameter,
     Cif2CifOptions,
-    CifDataFileParameter,
     get_cif_merge_parameter,
 )
 
@@ -164,7 +163,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
     @log_eel
     async def _prepare_and_launch_command(
         self, execute_request: msg_specs.CommandExecutionRequestNATS
-    ) -> tuple[BaseCommand, dict[str, BaseParameter | CifDataFileParameter], BaseCalculation]:
+    ) -> tuple[BaseCommand, dict[str, BaseParameter], BaseCalculation]:
         """Launch the requested command.
 
         Parameters
@@ -177,7 +176,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         -------
         BaseCommand
             A BaseCommand class for command which was launched successfully.
-        dict[str, BaseParameter | CifDataFileParameter]
+        dict[str, BaseParameter]
             A dict mapping of the parameter name and the QCrBox class
             representations of the value of that parameter. This is a collection
             of the parameters used by the command.
@@ -205,7 +204,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         self,
         command: BaseCommand,
         calc: BaseCalculation,
-        command_parameters: dict[str, BaseParameter | CifDataFileParameter],
+        command_parameters: dict[str, BaseParameter],
     ) -> None:
         """Handle saving the output from non-interactive commands/calculations.
 
@@ -216,7 +215,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         calc : BaseCalculation
             The BaseCalculation object used to track the execution of the
             non-interactive command.
-        command_parameters : dict[str, BaseParameter | CifDataFileParameter]
+        command_parameters : dict[str, BaseParameter]
             The parameters which were used to execute the command. These will be
             parsed as QCrBox data types.
 
@@ -252,7 +251,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         self,
         command: BaseCommand,
         calc: InteractiveSessionCalculation,
-        command_parameters: dict[str, BaseParameter | CifDataFileParameter],
+        command_parameters: dict[str, BaseParameter],
     ) -> None:
         """Handle saving the output from interactive commands/calculations.
 
@@ -263,7 +262,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         calc : BaseCalculation
             The BaseCalculation object used to track the execution of the
             non-interactive command.
-        command_parameters : dict[str, BaseParameter | CifDataFileParameter]
+        command_parameters : dict[str, BaseParameter]
             The parameters which were used to execute the command. These will be
             parsed as QCrBox data types.
 

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -189,7 +189,7 @@ class Cif2CifOptions(QCrBoxPydanticBaseModel):
         return f"Cif2CifOptions({self.application_yaml=}, {self.command_name=}, {self.parameter_name=})"
 
 
-class CifDataFileParameter(QCrBoxPydanticBaseModel):
+class CifDataFileParameter(BaseParameter):
     """Class for handling CIF datafile parameters.
 
     Attributes
@@ -365,7 +365,7 @@ _custom_dtypes = {
 _known_dtypes = _builtin_dtypes | _custom_dtypes
 
 def get_cif_merge_parameter(
-    command: "BaseCommand", parsed_parameters: dict[str, BaseParameter | CifDataFileParameter]
+    command: "BaseCommand", parsed_parameters: dict[str, BaseParameter]
 ) -> tuple[str | None, CifDataFileParameter | None]:
     """Get the parameter which will be used to merge to create the output CIF.
 
@@ -373,7 +373,7 @@ def get_cif_merge_parameter(
     ----------
     command : BaseCommand
         The BaseCommand object used to launch the command.
-    parsed_parameters : dict[str, BaseParameter | CifDataFileParameter]
+    parsed_parameters : dict[str, BaseParameter]
         A list of QCrBox data types which were used to execute the command.
 
     Returns


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #639 

## Summary of the changes

Updates the class which `QCrBox.cif_data_file` inherits from after discovering during work on #626 that it did not inherit from `BaseParameter` even though it could/should. This removes some now redundant code and type annotations, unifying parameter handling even further.

## How was it tested?

- Robot framework
- Pytest
- GitHub actions

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~