### PR TITLE
Update application template to build functional interactive application

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Fixed an issue where the `base-ancestor` image wouldn't build because `conda` couldn't resolve the environment
   dependencies.
 - Fixed an issue where environment variables were unset causing applications not to launch
+- Fixed an issue where `qcb init` would not create a valid template for interactive applications
 - And lots more!
 
 ### Documentation

--- a/services/applications/_template/hooks/post_gen_project.py
+++ b/services/applications/_template/hooks/post_gen_project.py
@@ -1,0 +1,13 @@
+import os
+
+
+def remove_dummy_gui_for_non_interactive():
+    app_type = "{{ cookiecutter.application_type }}"
+    if not app_type.startswith("Interactive GUI"):
+        path = "dummy_gui.py"
+        if os.path.exists(path):
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    remove_dummy_gui_for_non_interactive()

--- a/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/Dockerfile
@@ -18,7 +18,9 @@ COPY --chown=qcrbox:qcrbox \
      configure_{{ cookiecutter.application_slug }}.py \
      ${QCRBOX_HOME}
 
+{%- if cookiecutter.application_type in ["Interactive GUI (Linux)", "Interactive GUI (Windows)"] %}
 COPY --chown=qcrbox:qcrbox --chmod=755 dummy_gui.py ${QCRBOX_HOME}/bin/
+{%- endif %}
 
 USER ${QCRBOX_USER}
 WORKDIR ${QCRBOX_HOME}

--- a/services/applications/_template/{{cookiecutter.application_slug}}/config_{{cookiecutter.application_slug}}.yaml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/config_{{cookiecutter.application_slug}}.yaml
@@ -23,6 +23,7 @@ commands:
         valid_value:
           numeric_range: [0, 10]
 
+{%- if cookiecutter.application_type in ["Interactive GUI (Linux)", "Interactive GUI (Windows)"] %}
   - name: "interactive_session"
     implemented_as: "interactive_session"
     description: "Start dummy GUI in interactive mode"
@@ -36,7 +37,7 @@ commands:
         description: "Run command to launch the dummy GUI"
         call_pattern: "python dummy_gui.py {greeting}"
         used_basecommand_parameters: ["greeting"]
-
+{%- endif %}
 
 cif_entry_sets:
   - name: "example_entry_set"

--- a/services/applications/_template/{{cookiecutter.application_slug}}/config_{{cookiecutter.application_slug}}.yaml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/config_{{cookiecutter.application_slug}}.yaml
@@ -35,7 +35,7 @@ commands:
       run:
         implemented_as: "cli_command"
         description: "Run command to launch the dummy GUI"
-        call_pattern: "python dummy_gui.py {greeting}"
+        call_pattern: "python /opt/qcrbox/bin/dummy_gui.py {greeting}"
         used_basecommand_parameters: ["greeting"]
 {%- endif %}
 

--- a/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.prebuilt.yml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.prebuilt.yml
@@ -8,6 +8,8 @@ services:
       QCRBOX__REGISTRY__SERVER__PORT: "8000"
 {%- if cookiecutter.application_type in ["Interactive GUI (Linux)", "Interactive GUI (Windows)"] %}
       QCRBOX__GUI__PORT: ${QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT}
+    ports:
+      - "${QCRBOX_BIND_ADDRESS}:${QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT:?Must set env var QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT}:8080"
 {%- endif %}
     depends_on:
       qcrbox-registry:
@@ -24,12 +26,15 @@ services:
       traefik.http.routers.to-path-prefix.service: {{ cookiecutter.application_slug }}-service
       traefik.http.middlewares.redirect-gui-path.redirectregex.regex: ^http://(.+)/gui/{{ cookiecutter.application_slug }}(/?)$$
       traefik.http.middlewares.redirect-gui-path.redirectregex.replacement: http://{{ cookiecutter.application_slug }}.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
-
       traefik.http.routers.to-subdomain.rule: HostRegexp(`^{{ cookiecutter.application_slug }}\.gui\..+$$`)
       traefik.http.routers.to-subdomain.middlewares: redirect-gui-subdomain
       traefik.http.routers.to-subdomain.service: {{ cookiecutter.application_slug }}-service
       traefik.http.middlewares.redirect-gui-subdomain.redirectregex.regex: ^http://{{ cookiecutter.application_slug }}\.gui\.([^/]+)(/?)$$
       traefik.http.middlewares.redirect-gui-subdomain.redirectregex.replacement: http://{{ cookiecutter.application_slug }}.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
-
       traefik.http.services.{{ cookiecutter.application_slug }}-service.loadbalancer.server.scheme: http
       traefik.http.services.{{ cookiecutter.application_slug }}-service.loadbalancer.server.port: 8080
+    logging:
+      driver: "syslog"
+      options:
+        syslog-address: udp://127.0.0.1:514
+        tag: {{ cookiecutter.application_slug }}

--- a/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.prebuilt.yml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.prebuilt.yml
@@ -1,15 +1,14 @@
 services:
   {{ cookiecutter.application_slug }}:
     image: "${QCRBOX_DOCKER_REPO:?Must set env var QCRBOX_DOCKER_REPO}/{{ cookiecutter.application_slug }}:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
-    build:
-      context: services/applications/{{ cookiecutter.application_slug }}/
-      args:
-        QCRBOX_DOCKER_TAG: ${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}
     environment:
       QCRBOX_APPLICATION_DISPLAY_NAME: "{{ cookiecutter.application_name }}"
       QCRBOX__NATS__HOST: "qcrbox-nats"
       QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
       QCRBOX__REGISTRY__SERVER__PORT: "8000"
+{%- if cookiecutter.application_type in ["Interactive GUI (Linux)", "Interactive GUI (Windows)"] %}
+      QCRBOX__GUI__PORT: ${QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT}
+{%- endif %}
     depends_on:
       qcrbox-registry:
         condition: service_healthy

--- a/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.run.yml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.run.yml
@@ -8,6 +8,8 @@ services:
       QCRBOX__REGISTRY__SERVER__PORT: "8000"
 {%- if cookiecutter.application_type in ["Interactive GUI (Linux)", "Interactive GUI (Windows)"] %}
       QCRBOX__GUI__PORT: ${QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT}
+    ports:
+      - "${QCRBOX_BIND_ADDRESS}:${QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT:?Must set env var QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT}:8080"
 {%- endif %}
     depends_on:
       qcrbox-registry:
@@ -19,17 +21,22 @@ services:
     restart: unless-stopped
     labels:
       traefik.enable: true
-      traefik.http.routers.to-path-prefix.rule: Path(`/gui/{{ cookiecutter.application_slug }}`)
-      traefik.http.routers.to-path-prefix.middlewares: redirect-gui-path
-      traefik.http.routers.to-path-prefix.service: {{ cookiecutter.application_slug }}-service
-      traefik.http.middlewares.redirect-gui-path.redirectregex.regex: ^http://(.+)/gui/{{ cookiecutter.application_slug }}(/?)$$
-      traefik.http.middlewares.redirect-gui-path.redirectregex.replacement: http://{{ cookiecutter.application_slug }}.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
+      traefik.http.routers.to-{{cookiecutter.application_slug}}-path-prefix.rule: Path(`/gui/{{ cookiecutter.application_slug }}`)
+      traefik.http.routers.to-{{cookiecutter.application_slug}}-path-prefix.middlewares: redirect-gui-{{ cookiecutter.application_slug }}-path
+      traefik.http.routers.to-{{cookiecutter.application_slug}}-path-prefix.service: {{ cookiecutter.application_slug }}-service
+      traefik.http.middlewares.redirect-gui-{{cookiecutter.application_slug}}-path.redirectregex.regex: ^http://(.+)/gui/{{ cookiecutter.application_slug }}(/?)$$
+      traefik.http.middlewares.redirect-gui-{{cookiecutter.application_slug}}-path.redirectregex.replacement: http://{{ cookiecutter.application_slug }}.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
 
-      traefik.http.routers.to-subdomain.rule: HostRegexp(`^{{ cookiecutter.application_slug }}\.gui\..+$$`)
-      traefik.http.routers.to-subdomain.middlewares: redirect-gui-subdomain
-      traefik.http.routers.to-subdomain.service: {{ cookiecutter.application_slug }}-service
-      traefik.http.middlewares.redirect-gui-subdomain.redirectregex.regex: ^http://{{ cookiecutter.application_slug }}\.gui\.([^/]+)(/?)$$
-      traefik.http.middlewares.redirect-gui-subdomain.redirectregex.replacement: http://{{ cookiecutter.application_slug }}.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
+      traefik.http.routers.to-{{cookiecutter.application_slug}}-subdomain.rule: HostRegexp(`^{{ cookiecutter.application_slug }}\.gui\..+$$`)
+      traefik.http.routers.to-{{cookiecutter.application_slug}}-subdomain.middlewares: redirect-gui-{{ cookiecutter.application_slug }}-subdomain
+      traefik.http.routers.to-{{cookiecutter.application_slug}}-subdomain.service: {{ cookiecutter.application_slug }}-service
+      traefik.http.middlewares.redirect-gui-{{cookiecutter.application_slug}}-subdomain.redirectregex.regex: ^http://{{ cookiecutter.application_slug }}\.gui\.([^/]+)(/?)$$
+      traefik.http.middlewares.redirect-gui-{{cookiecutter.application_slug}}-subdomain.redirectregex.replacement: http://{{ cookiecutter.application_slug }}.gui.$$1/vnc.html?path=vnc&autoconnect=true&resize=remote&reconnect=true&show_dot=true
 
       traefik.http.services.{{ cookiecutter.application_slug }}-service.loadbalancer.server.scheme: http
       traefik.http.services.{{ cookiecutter.application_slug }}-service.loadbalancer.server.port: 8080
+    logging:
+      driver: "syslog"
+      options:
+        syslog-address: udp://127.0.0.1:514
+        tag: {{ cookiecutter.application_slug }}

--- a/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.run.yml
+++ b/services/applications/_template/{{cookiecutter.application_slug}}/docker-compose.{{cookiecutter.application_slug}}.run.yml
@@ -1,15 +1,14 @@
 services:
   {{ cookiecutter.application_slug }}:
     image: "qcrbox/{{ cookiecutter.application_slug }}:${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}"
-    build:
-      context: services/applications/{{ cookiecutter.application_slug }}/
-      args:
-        QCRBOX_DOCKER_TAG: ${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}
     environment:
       QCRBOX_APPLICATION_DISPLAY_NAME: "{{ cookiecutter.application_name }}"
       QCRBOX__NATS__HOST: "qcrbox-nats"
       QCRBOX__REGISTRY__SERVER__HOST: "qcrbox-registry"
       QCRBOX__REGISTRY__SERVER__PORT: "8000"
+{%- if cookiecutter.application_type in ["Interactive GUI (Linux)", "Interactive GUI (Windows)"] %}
+      QCRBOX__GUI__PORT: ${QCRBOX_{{ cookiecutter.application_slug.upper().replace("-", "_") }}_PORT}
+{%- endif %}
     depends_on:
       qcrbox-registry:
         condition: service_healthy

--- a/services/applications/dummy_gui/config_dummy_gui.yaml
+++ b/services/applications/dummy_gui/config_dummy_gui.yaml
@@ -19,7 +19,7 @@ commands:
       run:
         implemented_as: "cli_command"
         description: "Run command for rendering the dummy GUI"
-        call_pattern: "python dummy_gui.py {input_file}"
+        call_pattern: "python /opt/qcrbox/dummy_gui.py {input_file}"
         used_basecommand_parameters: ["input_file"]
       finalise:
         implemented_as: "python_callable"


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #642 

## Summary of the changes

This makes various changes to enable `qcb init` to create a function interactive application using the dummy GUI script. The main changes are using correct and unique labels for Traefik for each application and including the GUI port variable.

At the same time, we have cleaned up the template generation so only GUI code/configuration is included when a GUI application is being created.

## How was it tested?

- By creating an interactive gui app, building it and launching it through the frontend
- By creating a non-interactive app, building it and launching it through the frontend

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~