### PR TITLE
Improve NATS error handling for creating/closing commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@ However, there will be an initial period of stabilisation where this is not adhe
 - The application types in `qcb init` have been given more descriptive names: "CLI" -> "Non-interactive Command" and
   "GUI (Linux)" -> "Interactive GUI (Linux)". We have also reintroduced the "Interactive GUI (Windows)" application
   which lets you build an interactive application based on a Windows application running via Wine.
+- Improved error message return from command invocation/ending API endpoints when NATS is the reason for failure
 - And lots more!
 
 ### Issues Fixed

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -256,6 +256,11 @@ async def invoke_command(
     )
     try:
         response = await api_helpers.invoke_command(command_spec, nats_broker=nats_broker)
+    except (nats.errors.NoRespondersError, nats.errors.NoServersError) as exc:
+        raise QCrBoxAPIException(
+            detail=f"Failed to invoke command, unable to find {data.application_slug}-{data.application_version} container inbox",
+            status_code=404,
+        ) from exc
     except Exception as exc:
         raise QCrBoxAPIException(
             detail=f"Failed to invoke command due to an error in the server {str(exc)}", status_code=400
@@ -623,9 +628,14 @@ async def create_interactive_session_with_arguments(
     )
     try:
         response = await api_helpers.invoke_command(command_spec, nats_broker=nats_broker)
+    except (nats.errors.NoRespondersError, nats.errors.NoServersError) as exc:
+        raise QCrBoxAPIException(
+            detail=f"Failed to invoke command, unable to find {data.application_slug}-{data.application_version} container inbox",
+            status_code=404,
+        ) from exc
     except Exception as exc:
         raise QCrBoxAPIException(
-            detail=f"Failed to invoke command due to exception {str(exc)}", status_code=400
+            detail=f"Failed to invoke command due to exception {str(exc)}", status_code=500
         ) from exc
 
     if response["status"] != CalculationStatusEnum.SUBMITTED:

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -141,6 +141,7 @@ async def get_calculation_by_id(
     except api_helpers.CalculationNotFoundError as exc:
         raise QCrBoxAPIException(detail=f"Calculation not found: {id!r}", status_code=404) from exc
 
+
 @post(
     path="/calculations/{id:str}/stop",
     media_type=MediaType.JSON,
@@ -285,7 +286,6 @@ async def invoke_command(
     )
 
 
-
 # Data files -----------------------------------------------------------------------------------------------------------
 
 
@@ -362,6 +362,7 @@ async def download_data_file_by_id(
         media_type="application/octet-stream",
         headers={"Content-Disposition": f"attachment; filename={data_file_name!r}"},
     )
+
 
 @delete(
     path="/data-files/{id:str}",
@@ -494,6 +495,7 @@ async def create_dataset(
         },
         status_code=201,
     )
+
 
 @post(
     path="/datasets/{id:str}/append",

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -11,7 +11,7 @@ from faststream.nats import NatsBroker
 from litestar import MediaType, Request, Router, delete, get, post
 from litestar.datastructures import UploadFile
 from litestar.enums import RequestEncodingType
-from litestar.exceptions import HTTPException
+from litestar.exceptions import ClientException, HTTPException
 from litestar.params import Body, Parameter
 from litestar.response import Response
 from litestar.status_codes import HTTP_500_INTERNAL_SERVER_ERROR
@@ -242,7 +242,7 @@ async def get_command_by_id(id: int) -> schema.QCrBoxResponse[schema.CommandsRes
     summary="Invoke a command with arguments",
     tags=["commands"],
     operation_id="invoke_command",
-    responses={400: schema.BAD_REQUEST_ERROR, 500: schema.INTERNAL_SERVER_ERROR},
+    responses={400: schema.BAD_REQUEST_ERROR, 404: schema.NOT_FOUND_ERROR, 500: schema.INTERNAL_SERVER_ERROR},
 )
 async def invoke_command(
     data: Annotated[schema.InvokeCommandParameters, Body()],
@@ -261,6 +261,11 @@ async def invoke_command(
         raise QCrBoxAPIException(
             detail=f"Failed to invoke command, unable to find {data.application_slug}-{data.application_version} container inbox",
             status_code=404,
+        ) from exc
+    except ClientException as exc:
+        raise QCrBoxAPIException(
+            detail=f"Failed to invoke command due to incorrect request: {data}",
+            status_code=400,
         ) from exc
     except Exception as exc:
         raise QCrBoxAPIException(
@@ -616,7 +621,7 @@ async def get_interactive_session_by_id(
     summary="Create interactive session",
     tags=["interactive-sessions"],
     operation_id="create_interactive_session",
-    responses={400: schema.BAD_REQUEST_ERROR, 500: schema.INTERNAL_SERVER_ERROR},
+    responses={400: schema.BAD_REQUEST_ERROR, 404: schema.NOT_FOUND_ERROR, 500: schema.INTERNAL_SERVER_ERROR},
 )
 async def create_interactive_session_with_arguments(
     data: Annotated[schema.CreateInteractiveSessionParameters, Body()], nats_broker: NatsBroker
@@ -634,6 +639,11 @@ async def create_interactive_session_with_arguments(
         raise QCrBoxAPIException(
             detail=f"Failed to invoke command, unable to find {data.application_slug}-{data.application_version} container inbox",
             status_code=404,
+        ) from exc
+    except ClientException as exc:
+        raise QCrBoxAPIException(
+            detail=f"Failed to invoke command due to incorrect request: {data}",
+            status_code=400,
         ) from exc
     except Exception as exc:
         raise QCrBoxAPIException(

--- a/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
+++ b/pyqcrbox/pyqcrbox/registry/server/api/api_endpoints.py
@@ -5,6 +5,7 @@
 import traceback
 from typing import Annotated
 
+import nats.errors
 import nats.js.errors
 from faststream.nats import NatsBroker
 from litestar import MediaType, Request, Router, delete, get, post
@@ -159,6 +160,10 @@ async def stop_running_calculation(
         )
     except KeyError as exc:
         raise QCrBoxAPIException(detail=f"No calculation with ID {id!r}", status_code=404) from exc
+    except (nats.errors.NoRespondersError, nats.errors.NoServersError) as exc:
+        raise QCrBoxAPIException(
+            detail=f"Unable to contact application to request to stop calculation {id!r}", status_code=404
+        ) from exc
     except TypeError as exc:
         raise QCrBoxAPIException(
             detail="There was an internal server error when processing your request", status_code=500
@@ -664,6 +669,10 @@ async def close_interactive_session(
         )
     except KeyError as exc:
         raise QCrBoxAPIException(detail=f"Interactive session not found: {id!r}", status_code=404) from exc
+    except (nats.errors.NoRespondersError, nats.errors.NoServersError) as exc:
+        raise QCrBoxAPIException(
+            detail=f"Unable to contact application to request to close session {id!r}", status_code=404
+        ) from exc
     except TypeError as exc:
         raise QCrBoxAPIException(
             detail="There was an internal server error when processing your request", status_code=500


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #645 

## Summary of the changes

This improves the error handling for when NATS is the root failure for command invocation, or when stopping a command/interactive session.

## How was it tested?

- Invoking and ending a session for an old application in the frontend and looking at the response
- Robot framework

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`