### PR TITLE
Allow pathlib.Path to be returned from PythonCallable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,7 +50,8 @@ However, there will be an initial period of stabilisation where this is not adhe
 - The application types in `qcb init` have been given more descriptive names: "CLI" -> "Non-interactive Command" and
   "GUI (Linux)" -> "Interactive GUI (Linux)". We have also reintroduced the "Interactive GUI (Windows)" application
   which lets you build an interactive application based on a Windows application running via Wine.
-- Improved error message return from command invocation/ending API endpoints when NATS is the reason for failure
+- Improved error message return from command invocation/ending API endpoints when NATS is the reason for failure.
+- `PythonCallable` commands can now also return a `pathlib.Path` object in addition to a `str` of a file path.
 - And lots more!
 
 ### Issues Fixed

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/python_callable_calculation.py
@@ -77,8 +77,10 @@ class PythonCallableCalculation(BaseCalculation):
         if not self.return_value:
             logger.info("This calculation has no return value, nothing to store in the data manager")
             return None
-        if not isinstance(self.return_value, str):
-            exc_msg = f"The return value from the calculation must be an str, not type {type(self.return_value)}"
+        if not isinstance(self.return_value, (str, Path)):
+            exc_msg = (
+                f"The return value from the calculation must be str or pathlib.Path, not {type(self.return_value)}"
+            )
             logger.error(f"Unable to save output of calculation {self.calculation_id}: '{exc_msg}'")
             raise ValueError(exc_msg)
 

--- a/services/applications/dummy_cli/sample_functions.py
+++ b/services/applications/dummy_cli/sample_functions.py
@@ -31,7 +31,7 @@ def change_cif_name(input_cif: str, output_cif_name: str):
     output_cif_path = output_cif_path.with_suffix(".cif")
     shutil.copy(input_cif_path, output_cif_path)
 
-    return str(output_cif_path)
+    return output_cif_path
 
 
 def print_two_cif(cif1: str, cif2: str):

--- a/services/applications/dummy_gui/dummy_gui_commands.py
+++ b/services/applications/dummy_gui/dummy_gui_commands.py
@@ -1,11 +1,13 @@
+from pathlib import Path
+
 from pyqcrbox import logger
 
 
-def finalise_interactive(input_file: str) -> str:
+def finalise_interactive(input_file: str) -> Path:
     logger.debug(f"Finished dummy GUI session with input file {input_file!r}")
 
     output_file = input_file.replace(".cif", ".out.cif")
     with open(output_file, "w") as f:
         f.write("Dummy GUI output file")
     logger.debug(f"Wrote output file: {output_file!r}")
-    return output_file
+    return Path(output_file)


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #644 

## Summary of the changes

Enables being able to return a pathlib.Path object in addition to a str from a PythonCallable. Only the PythonCallable needs to be updated as CLI Commands do not support output and the finalise command in an interactive session has to be a PythonCallable. 

## How was it tested?

- Robot framework (updating a dummy_cli command to return a pathlib.Path)

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
- [x] I added automated tests for my changes
~~- [ ] I updated any relevant documentation~~
~~- [ ] I created separate GitHub issues for any follow-up work needed~~