### PR TITLE
Downgrade API version to 0.1.0 to match developer release version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ This project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 However, there will be an initial period of stabilisation where this is not adhered to
 (releases with version numbers `0.0.x`).
 
-## [Unreleased]
+## [v0.1.0]
 
 ### New Features
 

--- a/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
+++ b/pyqcrbox/pyqcrbox/registry/server/qcrbox_server.py
@@ -366,7 +366,7 @@ class QCrBoxServer(QCrBoxServerClientBase):
             },
             openapi_config=OpenAPIConfig(
                 title="QCrBox",
-                version="0.4.0",
+                version="0.1.0",
                 use_handler_docstrings=True,
             ),
             exception_handlers={


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #662 

## Summary of the changes

Downgrades the API version from > 0.2.0 down to 0.1.0 so the API version matches with the version number of the developer released.

## How was it tested?

- Robot framework
- GitHub Actions

## Additional considerations / follow-up work needed

We need to tag the other software components 0.1.0 as well.

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
- [x] I created separate GitHub issues for any follow-up work needed
~~- [ ] I added automated tests for my changes~~
~~- [ ] I updated any relevant documentation~~
