### PR TITLE
Restrict length of fields in YAML specifications

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,8 @@ However, there will be an initial period of stabilisation where this is not adhe
 - Fixed an issue where `qcb init` would not create a valid template for interactive applications
 - Fixed an issue where cif files would become lost during command execution, which resulted in incorrect unified cifs
   being returned to the registry.
+- Fixed an issue where long descriptions or text fields in the YAML specifications would cause the front end to crash.
+  Now descriptions and text fields are limited to 1023 and 255 characters, respectively.
 - And lots more!
 
 ### Documentation

--- a/docs/tutorials/wrap_gui_command.md
+++ b/docs/tutorials/wrap_gui_command.md
@@ -42,15 +42,19 @@ At any time you can press Ctrl+C to abort.
     2 - Interactive GUI (Linux)
     3 - Interactive GUI (Windows)
     Choose from [1/2/3] (1): 2
-  [2/7] application_slug (dummy_gui_tutorial): 
+  [2/7] application_slug (dummy_gui_tutorial):
   [3/7] application_name (Dummy Gui Tutorial): Dummy GUI
   [4/7] application_version (x.y.z): 0.1.0
   [5/7] description (Brief description of the application.): Dummy GUI for testing of interactive applications
-  [6/7] url (): 
-  [7/7] email (): 
+  [6/7] url ():
+  [7/7] email ():
 
 Created scaffolding for new application in '/home/user/QCrBox/services/applications/dummy_gui_tutorial'.
 ```
+
+> ### Description length
+>
+> The length of descriptions must be limited to 1024 characters. Descriptions which are larger will cause the application to be rejected by the QCrBox registry. This is true for all description fields.
 
 Note that when a GUI application container is created, a `dummy_gui.py` file is also copied over as an exemplar application, but we'll be replacing that in the next step.
 

--- a/docs/tutorials/wrap_gui_command.md
+++ b/docs/tutorials/wrap_gui_command.md
@@ -52,9 +52,9 @@ At any time you can press Ctrl+C to abort.
 Created scaffolding for new application in '/home/user/QCrBox/services/applications/dummy_gui_tutorial'.
 ```
 
-> ### Description length
+> ### Description and text input lengths
 >
-> The length of descriptions must be limited to 1024 characters. Descriptions which are larger will cause the application to be rejected by the QCrBox registry. This is true for all description fields.
+> The length of descriptions must be limited to 1023 characters, and other text fields are limited to 255 characters. Any text fields or descriptions which are larger than these will cause the application to be rejected during registration with the QCrBox registry.
 
 Note that when a GUI application container is created, a `dummy_gui.py` file is also copied over as an exemplar application, but we'll be replacing that in the next step.
 

--- a/docs/tutorials/wrap_python_command.md
+++ b/docs/tutorials/wrap_python_command.md
@@ -73,6 +73,10 @@ commands:
         default_value: false
 ```
 
+> ### Description length
+>
+> The length of descriptions must be limited to 1024 characters. Descriptions which are larger will cause the application to be rejected by the QCrBox registry. This is true for all description fields.
+
 ### Specifying Required CIF Entries For Input
 
 Next, we must specify which CIF entries have to be in the input CIF file for our command to function, and what to add into the output CIF files. If we take a look at the `cif_to_search_pars` function in the `simple_cod_module.py` script, we can determine these entries. Next, we need to ensure that `required_entries:` under the `input_cif` parameter aligns with the `name:` and `type:` sections of that parameter for proper structure:

--- a/docs/tutorials/wrap_python_command.md
+++ b/docs/tutorials/wrap_python_command.md
@@ -73,9 +73,9 @@ commands:
         default_value: false
 ```
 
-> ### Description length
+> ### Description and text input lengths
 >
-> The length of descriptions must be limited to 1024 characters. Descriptions which are larger will cause the application to be rejected by the QCrBox registry. This is true for all description fields.
+> The length of descriptions must be limited to 1023 characters, and other text fields are limited to 255 characters. Any text fields or descriptions which are larger than these will cause the application to be rejected during registration with the QCrBox registry.
 
 ### Specifying Required CIF Entries For Input
 

--- a/pyqcrbox/pyqcrbox/data_management/data_manager.py
+++ b/pyqcrbox/pyqcrbox/data_management/data_manager.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import nats.js.errors
 
-from pyqcrbox import logger
+from pyqcrbox import logger, settings
 from pyqcrbox.data_management.data_file import DataFile
 from pyqcrbox.data_management.dataset import Dataset
 from pyqcrbox.data_management.errors import DatasetNotFoundError
@@ -430,6 +430,9 @@ class DataManager(ABC):
             The ID of the data file
 
         """
+        if len(filename) > settings.db.max_text_length:
+            raise ValueError("QCrBox does not support file names which are greater than 255 characters long")
+
         qcrbox_file_id = _qcrbox_file_id or generate_data_file_id()
         file_extension = Path(filename).suffix[1:]
         data_file = DataFile(

--- a/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
+++ b/pyqcrbox/pyqcrbox/registry/client/executable_command/interactive_session_calculation.py
@@ -11,9 +11,7 @@ from pyqcrbox.registry.client.executable_command.error import (
     FinaliseCommandFailure,
     PrepareCommandFailure,
     RunCommandFailure,
-    error_dialog_box,
 )
-from pyqcrbox.services import QCRBOX_GLOBAL_SERVICES_REGISTRY
 from pyqcrbox.sql_models import CalculationStatusEnum
 from pyqcrbox.sql_models.parameter_spec.base_parameter_spec import Cif2CifOptions, CifDataFileParameter
 
@@ -95,7 +93,8 @@ class InteractiveSessionCalculation(BaseCalculation):
         output_file = self.finalise_calc.return_value
         if not output_file:
             logger.warning("The finalise calculation for the interactive session does not return an output file")
-            return None
+            self.output_dataset_id = None
+            return self.output_dataset_id
 
         output_file = Path(output_file)
         if not output_file.exists() or not output_file.is_file():

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -489,11 +489,15 @@ class QCrBoxClient(QCrBoxServerClientBase):
             return
         logger.debug(f"Calculation {calc.calculation_id} has finished")
 
-        if command.type != "interactive_session":
-            # Note that this method will also remove the calculation directory
-            await self._handle_non_interactive_output(command, calc, parameters)
-        else:
-            await self._handle_interactive_output(command, calc, parameters)
+        try:
+            if command.type != "interactive_session":
+                # Note that this method will also remove the calculation directory
+                await self._handle_non_interactive_output(command, calc, parameters)
+            else:
+                await self._handle_interactive_output(command, calc, parameters)
+        except Exception as exc:
+            await self._handle_calculation_failure(calc, exc)
+            return
 
         logger.debug("Updating calculation status after calculation has finished")
         await self.data_manager.update_calculation_status(await calc.get_status_details())

--- a/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
+++ b/pyqcrbox/pyqcrbox/registry/client/qcrbox_client.py
@@ -270,10 +270,10 @@ class QCrBoxClient(QCrBoxServerClientBase):
         """
         from pyqcrbox.registry.client.executable_command.error import FinaliseCommandFailure, error_dialog_box
 
-        logger.debug(f"Adding output from interactive command {command.name} into data manager")
-
         if not calc.finalise_calc:
             logger.info(f"Interactive session {calc.calculation_id} has no finalise method, so cannot get output")
+            calc.is_closed = True
+            calc.session_closed_event.set()
             return
 
         logger.debug("Waiting for finalise command to finish running to get output")
@@ -289,7 +289,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
             raise calc.exception from calc.finalise_calc.exception_raised
 
         logger.debug("Finalise command has finished")
-
+        logger.debug(f"Adding output from interactive command {command.name} into data manager")
         try:
             parameter_name, cif_parameter, output_path = await get_cif_merge_parameter(command, command_parameters)
 
@@ -630,6 +630,7 @@ class QCrBoxClient(QCrBoxServerClientBase):
         await calc.terminate()
 
         self._remove_calculation_work_dir()
+        await self.data_manager.update_calculation_status(await calc.get_status_details())
         self.status.set_idle()
         logger.debug("Interactive session has been closed and client set to idle")
 

--- a/pyqcrbox/pyqcrbox/settings.py
+++ b/pyqcrbox/pyqcrbox/settings.py
@@ -50,6 +50,8 @@ class DatabaseSettings(QCrBoxSettingsBaseModel):
     url: SQLiteDsn = "sqlite:///:memory:"
     connect_args: dict = {"check_same_thread": False}
     echo: bool = False
+    max_desc_length: int = 1023
+    max_text_length: int = 255
 
     def create_db_and_tables(
         self,

--- a/pyqcrbox/pyqcrbox/settings.py
+++ b/pyqcrbox/pyqcrbox/settings.py
@@ -131,7 +131,7 @@ class StructlogRendererEnum(Enum):
 
 
 class LoggingSettings(QCrBoxSettingsBaseModel):
-    log_func_entry_exit: bool = False
+    log_func_entry_exit: bool = True
     log_level: str = "DEBUG" if IS_RUNNING_DEBUG_MODE or IS_RUNNING_INSIDE_TESTS else "INFO"
     renderer: StructlogRendererEnum = StructlogRendererEnum.JSON
 

--- a/pyqcrbox/pyqcrbox/sql_models/application_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/application_spec.py
@@ -7,6 +7,7 @@ from typing import Self
 import yaml
 from pydantic import Field, PrivateAttr, field_validator, model_validator
 
+from pyqcrbox import settings
 from pyqcrbox._version import __version__ as pyqcrbox_version
 
 from .. import helpers
@@ -60,16 +61,16 @@ class ApplicationSpecBase(QCrBoxPydanticBaseModel):
 
     """
 
-    name: str
-    slug: str
-    version: str
-    pyqcrbox_version: str = pyqcrbox_version
-    description: str | None = None
-    url: str | None = None
-    email: str | None = None
-    doi: str | None = None
+    name: str = Field(max_length=settings.db.max_text_length)
+    slug: str = Field(max_length=settings.db.max_text_length)
+    version: str = Field(max_length=settings.db.max_text_length)
+    pyqcrbox_version: str = Field(default=pyqcrbox_version, max_length=settings.db.max_desc_length)
+    description: str | None = Field(default=None, max_length=settings.db.max_desc_length)
+    url: str | None = Field(default=None, max_length=settings.db.max_text_length)
+    email: str | None = Field(default=None, max_length=settings.db.max_text_length)
+    doi: str | None = Field(default=None, max_length=settings.db.max_text_length)
     yaml_file_path: str | None = Field(exclude=True, default=None)
-    gui_port: str | None = None
+    gui_port: str | None = Field(default=None, max_length=settings.db.max_text_length)
 
     @field_validator("yaml_file_path", mode="before")
     @classmethod

--- a/pyqcrbox/pyqcrbox/sql_models/command_spec/base_command_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/command_spec/base_command_spec.py
@@ -1,5 +1,9 @@
 from enum import Enum
 
+from pydantic import Field
+
+from pyqcrbox import settings
+
 from ..base import QCrBoxPydanticBaseModel
 from ..parameter_spec import ParameterSpecDiscriminatedUnion
 
@@ -49,8 +53,8 @@ class BaseCommandSpec(QCrBoxPydanticBaseModel):
 
     """
 
-    name: str
-    description: str
+    name: str = Field(max_length=settings.db.max_text_length)
+    description: str | None = Field(default=None, max_length=settings.db.max_desc_length)
     implemented_as: ImplementedAs
     parameters: list[ParameterSpecDiscriminatedUnion]
     merge_cif_su: bool = False

--- a/pyqcrbox/pyqcrbox/sql_models/command_spec/command_spec_db.py
+++ b/pyqcrbox/pyqcrbox/sql_models/command_spec/command_spec_db.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Any
 
 from sqlmodel import JSON, Field, Relationship, UniqueConstraint
 
+from pyqcrbox import settings
+
 from ..base import QCrBoxBaseSQLModel
 from .base_command_spec import ImplementedAs
 from .command_spec import CommandSpec
@@ -17,8 +19,8 @@ class CommandSpecDB(QCrBoxBaseSQLModel, table=True):
     __table_args__ = (UniqueConstraint("name", "application_id"),)
     __pydantic_model_cls__ = CommandSpec
 
-    name: str
-    description: str = ""
+    name: str = Field(max_length=settings.db.max_text_length)
+    description: str | None = Field(default=None, max_length=settings.db.max_desc_length)
     merge_cif_su: bool = False
     implemented_as: ImplementedAs
     doi: str | None = None

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -2,12 +2,13 @@ import re
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, Union
 
 import nats.js.errors as nats_errors
 import svcs
-from pydantic import BeforeValidator, Field, field_validator, model_validator
+from pydantic import BeforeValidator, Field, constr, field_validator, model_validator
 
+from pyqcrbox import settings
 from pyqcrbox.debug import log_eel
 from pyqcrbox.logging import logger
 
@@ -544,7 +545,7 @@ def parse_parameter_as_its_dtype(v: Any, dtype_str: str) -> Any:
     return _known_dtypes[dtype_str](**v)
 
 
-DTypeAsStr = Annotated[str, BeforeValidator(verify_dtype_is_a_known_type)]
+DTypeAsStr = Annotated[constr(max_length=settings.db.max_text_length), BeforeValidator(verify_dtype_is_a_known_type)]
 DefaultValueAsStr = Annotated[BuiltinParameter, BeforeValidator(parse_parameter_default_value_as_string)]
 
 
@@ -638,10 +639,10 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
 
     """
 
-    name: str
-    dtype: DTypeAsStr
-    description: str = ""
-    default_value: str | int | float | bool | None = None
+    name: str = Field(max_length=settings.db.max_text_length)
+    dtype: DTypeAsStr = Field(max_length=settings.db.max_text_length)
+    description: str | None = Field(default=None, max_length=settings.db.max_desc_length)
+    default_value: Union[constr(max_length=settings.db.max_desc_length), int, float, bool, None] = Field(None)  # pyright: ignore[reportInvalidTypeForm]
     valid_value: ParameterValidationSpec | None = None
 
     # We are marking all parameters as being REQUIRED and freezing the choice.

--- a/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
+++ b/pyqcrbox/pyqcrbox/sql_models/parameter_spec/base_parameter_spec.py
@@ -642,7 +642,7 @@ class BaseParameterSpec(QCrBoxPydanticBaseModel):
     name: str = Field(max_length=settings.db.max_text_length)
     dtype: DTypeAsStr = Field(max_length=settings.db.max_text_length)
     description: str | None = Field(default=None, max_length=settings.db.max_desc_length)
-    default_value: Union[constr(max_length=settings.db.max_desc_length), int, float, bool, None] = Field(None)  # pyright: ignore[reportInvalidTypeForm]
+    default_value: Union[constr(max_length=settings.db.max_desc_length), int, float, bool, None] = None  # pyright: ignore[reportInvalidTypeForm]
     valid_value: ParameterValidationSpec | None = None
 
     # We are marking all parameters as being REQUIRED and freezing the choice.

--- a/pyqcrbox/robot_tests/3_interactive_commands.robot
+++ b/pyqcrbox/robot_tests/3_interactive_commands.robot
@@ -183,6 +183,26 @@ The commands API should also be able to launch an interactive session
     Should Be Equal    ${interactive_sessions[0]["session_id"]}    ${invoke_payload['calculation_id']}
 
 
+Interactive sessions should be closable if they don't return an output dataset
+    [Documentation]    This checks that an interactive sessions closes properly when there is no output to return
+
+    VAR    &{input_file}=    data_file_id=${TEST_DATA_FILE_ID}
+    VAR    &{arguments}=    input_file=${input_file}
+    ${response}=    Invoke Command With Arguments    dummy_gui    0.1.0    no_output    ${arguments}
+    ${invoke_payload}=    Check Response Structure And Get Payload    ${response}
+    Check Response Content Has Attributes    ${invoke_payload}    calculation_id
+    Sleep    5s    "Waiting for interactive session to be registered and start"
+
+    ${response}=    Send API Request
+    ...    POST
+    ...    ${SESSION_ALIAS}
+    ...    /interactive-sessions/${invoke_payload['calculation_id']}/close
+    ...    200
+    ${close_payload}=    Check Response Structure And Get Payload    ${response}
+    Check Response Content Has Attributes    ${close_payload}    interactive_sessions
+    VAR    ${interactive_sessions}=    ${close_payload["interactive_sessions"]}
+    Should Be Equal    ${interactive_sessions[0]["session_id"]}    ${invoke_payload['calculation_id']}
+
 *** Keywords ***
 Setup Suite
     [Documentation]    Setup the test environment for this suite

--- a/scripts/validate_application_yaml.sh
+++ b/scripts/validate_application_yaml.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-applications=$(find -name "config_*.yaml" | grep -Ev "dummy|_template")
+applications=$(find -name "config_*.yaml" | grep -Ev "dummy|_template|eval1x|crysalis-pro")
 failed_apps=()
 
 for app in $applications; do

--- a/services/applications/dummy_gui/config_dummy_gui.yaml
+++ b/services/applications/dummy_gui/config_dummy_gui.yaml
@@ -27,5 +27,17 @@ commands:
         import_path: "dummy_gui_commands"
         callable_name: "finalise_interactive"
         used_basecommand_parameters: ["input_file"]
-
+  - name: "no_output"
+    implemented_as: "interactive_session"
+    description: "Start a dummy GUI which returns no output"
+    parameters:
+      - name: "input_file"
+        dtype: "QCrBox.cif_data_file"
+        description: "The file to open in the dummy GUI"
+    interactive_lifecycle:
+      run:
+        implemented_as: "cli_command"
+        description: "Run command for rendering the dummy GUI"
+        call_pattern: "python /opt/qcrbox/dummy_gui.py {input_file}"
+        used_basecommand_parameters: ["input_file"]
 qcrbox_yaml_spec_version: "0.1"


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #666 
- Fixes #671 

## Summary of the changes

Adds restrictions to the fields in the Pydnatic models used for the YAML specifications. Specifically long description fields can be 1023 characters, whilst all other text input is limited to 255 characters.

This was done to bring it in line with the limitations of the frontend database. It was too much work at this stage to rework that database. Given the NoSQL nature of the backend's data manager and YAML specification system, it was easier to add the restrictions here. 

There is also a hotfix in here related to interactive sessions not being closable in some instances if no output is returned (if there is no finalise command). 

## How was it tested?

- Building applications with long description paths
- Validation the YAML using `qcb validate`
- Robot framework and GitHub actions
- Launching an application in the front end

## Additional considerations / follow-up work needed

N/A

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- [x] I added a changelog entry in `docs/CHANGELOG.md`
- [x] I updated any relevant documentation
- [x] I added automated tests for my changes