### PR TITLE
697 small olex2 container fixes

### DIFF
--- a/services/applications/olex2_linux/Dockerfile
+++ b/services/applications/olex2_linux/Dockerfile
@@ -14,10 +14,11 @@ RUN apt-get update -y && \
 RUN sed -i 's/^# en_GB/en_GB/' /etc/locale.gen && \
     locale-gen --purge en_GB
 
-# Dirty hack to get Olex headless to run
+# Link missing Olex2 libraries
 RUN cd /lib/x86_64-linux-gnu/ && \
     ln -s libreadline.so.8 libreadline.so.6 && \
-    ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 libtinfo.so.5
+    ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 libtinfo.so.5 && \
+    ln -s /lib/x86_64-linux-gnu/libjpeg.so.62 /lib/x86_64-linux-gnu/libjpeg.so.8
 
 # create folder and then work as user to avoid a RUN chown
 

--- a/services/applications/olex2_linux/config_olex2.yaml
+++ b/services/applications/olex2_linux/config_olex2.yaml
@@ -18,7 +18,7 @@ commands:
         dtype: "QCrBox.cif_data_file"
         description: "The CIF file to open in Olex2"
         required_entry_sets: [ "cell_data", "diffraction_data" ]
-        optional_entry_sets: [ "atom_data", "aspheric_form_factors" ]
+        optional_entry_sets: [ "atom_data", "aspheric_form_factors", "previous_quality_indicators" ]
         merge_su: Yes
         custom_categories: [ "iucr", "shelx" ]
       - name: "output_cif_name"
@@ -144,6 +144,7 @@ cif_entry_sets:
       "_atom_type_scat_dispersion_source",
       "_space_group_crystal_system",
       "_atom_site_refinement_flags_posn",
+      "_atom_site_disorder_group",
       "_atom_site_aniso_label",
       "_atom_site_aniso_U_11",
       "_atom_site_aniso_U_22",
@@ -167,6 +168,33 @@ cif_entry_sets:
       "_aspheric_ff.form_factor_real",
       "_aspheric_ff.form_factor_imag",
     ]
+
+  - name: "previous_quality_indicators"
+    required: [
+      "_refine_diff_density_max",
+      "_refine_diff_density_min",
+      "_refine_diff_density_rms",
+      "_refine_ls_d_res_high",
+      "_refine_ls_d_res_low",
+      "_refine_ls_goodness_of_fit_ref",
+      "_refine_ls_hydrogen_treatment",
+      "_refine_ls_matrix_type",
+      "_refine_ls_number_constraints",
+      "_refine_ls_number_parameters",
+      "_refine_ls_number_reflns",
+      "_refine_ls_number_restraints",
+      "_refine_ls_R_factor_all",
+      "_refine_ls_R_factor_gt",
+      "_refine_ls_restrained_S_all",
+      "_refine_ls_shift/su_max",
+      "_refine_ls_shift/su_mean",
+      "_refine_ls_structure_factor_coef",
+      "_refine_ls_weighting_details",
+      "_refine_ls_weighting_scheme",
+      "_refine_ls_wR_factor_gt",
+      "_refine_ls_wR_factor_ref",
+    ]
+
   - name: all_olex_optional
     optional : [
       "_audit_creation_date",

--- a/services/applications/olex2_linux/olex2_glue.py
+++ b/services/applications/olex2_linux/olex2_glue.py
@@ -22,7 +22,7 @@ def rename_databock_to_original(input_cif_path: Path, output_cif_path: Path):
 
     output_text = output_cif_path.read_text(encoding="UTF-8")
     # we want to capture data blocks in an fcf entry
-    output_text = re.sub(r"^([data_[^\s]+)", f"data_{dataset_name}", output_text, flags=re.MULTILINE)
+    output_text = re.sub(r"^data_[^\s]+", f"data_{dataset_name}", output_text, flags=re.MULTILINE)
     output_cif_path.write_text(output_text, encoding="UTF-8")
     
 

--- a/services/applications/olex2_linux/olex2_glue.py
+++ b/services/applications/olex2_linux/olex2_glue.py
@@ -1,11 +1,30 @@
 import shutil
 from pathlib import Path
+import re
 
 from qcrboxtools.cif.file_converter.tsc import TSCBFile
 from qcrboxtools.robots.olex2 import Olex2Socket
 
 YAML_PATH = Path(__file__).parent / "config_olex2.yaml"
 
+def rename_databock_to_original(input_cif_path: Path, output_cif_path: Path):
+    # find input dataset name
+    dataset_pattern = re.compile(r"data_([^\s])+")
+    with open(input_cif_path, "r", encoding="UTF-8") as cif:
+        for line in cif:
+            match = dataset_pattern.match(line)
+            if match:
+                dataset_name = match.group(0)[5:]
+                break
+        else:
+            raise ValueError("No dataset name found in CIF file.")
+    # rename data block to original
+
+    output_text = output_cif_path.read_text(encoding="UTF-8")
+    # we want to capture data blocks in an fcf entry
+    output_text = re.sub(r"^([data_[^\s]+)", f"data_{dataset_name}", output_text, flags=re.MULTILINE)
+    output_cif_path.write_text(output_text, encoding="UTF-8")
+    
 
 def generate_tscb_if_needed(input_cif):
     try:
@@ -24,6 +43,7 @@ def refine(
     weight_cycles: int,
 ):
     input_cif_path = Path(input_cif)
+
     output_cif_path = input_cif_path.parent / output_cif_name
     tsc_path = generate_tscb_if_needed(input_cif_path)
 
@@ -35,6 +55,8 @@ def refine(
     _ = olex2_socket.run_full_refinement(work_cif_path, tsc_path, n_cycles=ls_cycles, refine_starts=weight_cycles)
 
     shutil.copy(work_cif_path, output_cif_path)
+
+    rename_databock_to_original(input_cif_path, output_cif_path)
 
     return str(output_cif_path.absolute())
 
@@ -54,5 +76,7 @@ def run_commands(input_cif: str, output_cif_name: str, cmd_file: str):
     olex2_socket.send_command(work_cif_path, tsc_path, cmd_string)
 
     shutil.copy(work_cif_path, output_cif_path)
+
+    rename_databock_to_original(input_cif_path, output_cif_path)
 
     return str(output_cif_path.absolute())

--- a/services/applications/olex2_linux/olex2_glue.py
+++ b/services/applications/olex2_linux/olex2_glue.py
@@ -7,14 +7,14 @@ from qcrboxtools.robots.olex2 import Olex2Socket
 
 YAML_PATH = Path(__file__).parent / "config_olex2.yaml"
 
-def rename_databock_to_original(input_cif_path: Path, output_cif_path: Path):
+def rename_datablock_to_original(input_cif_path: Path, output_cif_path: Path):
     # find input dataset name
-    dataset_pattern = re.compile(r"data_([^\s])+")
+    dataset_pattern = re.compile(r"data_([^\s]+)")
     with open(input_cif_path, "r", encoding="UTF-8") as cif:
         for line in cif:
             match = dataset_pattern.match(line)
             if match:
-                dataset_name = match.group(0)[5:]
+                dataset_name = match.group(1)
                 break
         else:
             raise ValueError("No dataset name found in CIF file.")
@@ -56,7 +56,7 @@ def refine(
 
     shutil.copy(work_cif_path, output_cif_path)
 
-    rename_databock_to_original(input_cif_path, output_cif_path)
+    rename_datablock_to_original(input_cif_path, output_cif_path)
 
     return str(output_cif_path.absolute())
 
@@ -77,6 +77,6 @@ def run_commands(input_cif: str, output_cif_name: str, cmd_file: str):
 
     shutil.copy(work_cif_path, output_cif_path)
 
-    rename_databock_to_original(input_cif_path, output_cif_path)
+    rename_datablock_to_original(input_cif_path, output_cif_path)
 
     return str(output_cif_path.absolute())


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #697 


## Summary of the changes
Fixes to the olex2 container.
 - Added missing entries for reference in input
 - Added missing dependency link for the newest olex2 version
 - Fix dataset output of the non-interactive commands


## How was it tested?
 - Ran command tester and interactive session manually

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving 
- ~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
- ~~- [ ] I added automated tests for my changes~~
- ~~- [ ] I updated any relevant documentation~~
- ~~- [ ] I created separate GitHub issues for any follow-up work needed~~
