### PR TITLE
Fix Wine text rendering issues

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -39,7 +39,6 @@ services:
         QCRBOX_DOCKER_TAG: ${QCRBOX_DOCKER_TAG:?Must set env var QCRBOX_DOCKER_TAG}
         QCRBOX_ROOT_DIR: ${QCRBOX_ROOT_DIR:?Must set env var QCRBOX_ROOT_DIR}
         QCRBOX_WINE_INSTALLATIONS_DIR: ${QCRBOX_WINE_INSTALLATIONS_DIR:?Must set env var QCRBOX_WINE_INSTALLATIONS_DIR}
-        QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH: ${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH:?Must set env var QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}
         # We set a default value for QCRBOX_WINEARCH just so that we can run the base-wine container for debugging,
         # but this must be set by each application as required.
         QCRBOX_WINEARCH: ${QCRBOX_WINEARCH:-win32}

--- a/services/applications/mopro/Dockerfile
+++ b/services/applications/mopro/Dockerfile
@@ -31,6 +31,9 @@ ARG WINEARCH="win64"
 ENV WINEARCH=${WINEARCH}
 ENV QCRBOX_ROOT_DIR=${QCRBOX_ROOT_DIR}
 
+# Qt environment variable for Wine compatibility
+ENV QT_X11_NO_MITSHM=1
+
 COPY configure_mopro.py ./
 COPY config_mopro.yaml ./
 COPY templates ./templates

--- a/services/applications/mopro/run_once.sh
+++ b/services/applications/mopro/run_once.sh
@@ -5,6 +5,49 @@
 wine reg add "HKCU\\Control Panel\\Desktop" /v FontSmoothing /t REG_SZ /d 2 /f 2>/dev/null || true
 wine reg add "HKCU\\Control Panel\\Desktop" /v FontSmoothingType /t REG_DWORD /d 2 /f 2>/dev/null || true
 
+# Create MoPro configuration files if they don't exist
+mkdir -p "$MOPRO_ROAMING_PROFILE_DIR"
+
+if [ ! -f "$MOPRO_ROAMING_PROFILE_DIR/mopro.ini" ]; then
+    # Create mopro.ini with default paths
+    sed -e "s|{{mopro_workdir}}|Z:\\home\\qcrbox|g" \
+        -e "s|{{mopro_path}}|$MOPRO_PATH|g" \
+        -e "s|{{vmopro_path}}|$VMOPRO_PATH|g" \
+        -e "s|{{imopro_path}}|$IMOPRO_PATH|g" \
+        -e "s|{{mopro_viewer_path}}|$MOPRO_VIEWER_PATH|g" \
+        -e "s|{{tabl_path}}|$MOPRO_LIB_PATH\\mopro_v24.tab|g" \
+        -e "s|{{wave_path}}|$MOPRO_LIB_PATH\\WAVEF_Su_Coppens_relativistic|g" \
+        -e "s|{{anom_path}}|$MOPRO_LIB_PATH\\asf_Kissel.dat|g" \
+        -e "s|{{dens_path}}|$MOPRO_LIB_PATH\\dens_sph_neu.tab|g" \
+        /opt/qcrbox/templates/mopro.ini > "$MOPRO_ROAMING_PROFILE_DIR/mopro.ini"
+fi
+
+if [ ! -f "$MOPRO_ROAMING_PROFILE_DIR/moprogui.ini" ]; then
+    sed -e "s|{{mopro_workdir}}|Z:\\home\\qcrbox|g" \
+        -e "s|{{mopro_path}}|$MOPRO_PATH|g" \
+        -e "s|{{vmopro_path}}|$VMOPRO_PATH|g" \
+        -e "s|{{imopro_path}}|$IMOPRO_PATH|g" \
+        -e "s|{{mopro_viewer_path}}|$MOPRO_VIEWER_PATH|g" \
+        -e "s|{{tabl_path}}|$MOPRO_LIB_PATH\\mopro_v24.tab|g" \
+        -e "s|{{wave_path}}|$MOPRO_LIB_PATH\\WAVEF_Su_Coppens_relativistic|g" \
+        -e "s|{{anom_path}}|$MOPRO_LIB_PATH\\asf_Kissel.dat|g" \
+        -e "s|{{dens_path}}|$MOPRO_LIB_PATH\\dens_sph_neu.tab|g" \
+        /opt/qcrbox/templates/moprogui.ini > "$MOPRO_ROAMING_PROFILE_DIR/moprogui.ini"
+fi
+
+if [ ! -f "$MOPRO_ROAMING_PROFILE_DIR/moproviewer.ini" ]; then
+    sed -e "s|{{mopro_workdir}}|Z:\\home\\qcrbox|g" \
+        -e "s|{{mopro_path}}|$MOPRO_PATH|g" \
+        -e "s|{{vmopro_path}}|$VMOPRO_PATH|g" \
+        -e "s|{{imopro_path}}|$IMOPRO_PATH|g" \
+        -e "s|{{mopro_viewer_path}}|$MOPRO_VIEWER_PATH|g" \
+        -e "s|{{tabl_path}}|$MOPRO_LIB_PATH\\mopro_v24.tab|g" \
+        -e "s|{{wave_path}}|$MOPRO_LIB_PATH\\WAVEF_Su_Coppens_relativistic|g" \
+        -e "s|{{anom_path}}|$MOPRO_LIB_PATH\\asf_Kissel.dat|g" \
+        -e "s|{{dens_path}}|$MOPRO_LIB_PATH\\dens_sph_neu.tab|g" \
+        /opt/qcrbox/templates/moproviewer.ini > "$MOPRO_ROAMING_PROFILE_DIR/moproviewer.ini"
+fi
+
 wine $MOPRO_GUI_PATH &
 
 sleep 2

--- a/services/applications/mopro/run_once.sh
+++ b/services/applications/mopro/run_once.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Fonts are already extracted and available in Wine prefix from Dockerfile build
+# Enable RGB subpixel font smoothing to fix missing vertical strokes
+wine reg add "HKCU\\Control Panel\\Desktop" /v FontSmoothing /t REG_SZ /d 2 /f 2>/dev/null || true
+wine reg add "HKCU\\Control Panel\\Desktop" /v FontSmoothingType /t REG_DWORD /d 2 /f 2>/dev/null || true
+
 wine $MOPRO_GUI_PATH &
 
 sleep 2

--- a/services/base_images/base_novnc/supervisord.base_novnc.conf
+++ b/services/base_images/base_novnc/supervisord.base_novnc.conf
@@ -1,6 +1,6 @@
 [program:x11]
 priority=0
-command=/usr/bin/Xtigervnc -desktop "%(ENV_QCRBOX_APPLICATION_DISPLAY_NAME)s" -localhost -rfbport 5900 -SecurityTypes None -AlwaysShared -AcceptKeyEvents -AcceptPointerEvents -AcceptSetDesktopSize -SendCutText -AcceptCutText :0
+command=/usr/bin/Xtigervnc -desktop "%(ENV_QCRBOX_APPLICATION_DISPLAY_NAME)s" -localhost -rfbport 5900 -SecurityTypes None -AlwaysShared -AcceptKeyEvents -AcceptPointerEvents -AcceptSetDesktopSize -SendCutText -AcceptCutText -dpi 96 -depth 24 :0
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/services/base_images/base_wine/Dockerfile
+++ b/services/base_images/base_wine/Dockerfile
@@ -22,21 +22,10 @@ RUN dpkg --add-architecture i386 && \
     rm -rf /var/lib/apt/lists && \
     true
 
-# Install cabextract (needed to extract font files) and fontconfig
+# Install fontconfig for Wine font rendering configuration
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends cabextract fontconfig && \
+    apt-get install -y --no-install-recommends fontconfig && \
     rm -rf /var/lib/apt/lists
-
-# Manually install Microsoft Core Fonts (ARM-compatible approach)
-# Download and extract the core fonts that Windows applications expect
-RUN mkdir -p /usr/share/fonts/truetype/msttcorefonts && \
-    cd /tmp && \
-    for font in andale32.exe arial32.exe arialb32.exe comic32.exe courie32.exe georgi32.exe impact32.exe times32.exe trebuc32.exe verdan32.exe webdin32.exe; do \
-        wget -q https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/$font && \
-        cabextract -q -d /usr/share/fonts/truetype/msttcorefonts $font && \
-        rm $font; \
-    done && \
-    chmod 644 /usr/share/fonts/truetype/msttcorefonts/*
 
 # Install Mono (https://wiki.winehq.org/Mono)
 RUN mkdir -p /opt/wine-${WINE_BRANCH}/share/wine/mono && \
@@ -86,31 +75,35 @@ RUN export WINEARCH="win64" && \
 
 # Configure fontconfig to use RGB subpixel rendering (fixes missing vertical strokes)
 RUN mkdir -p /etc/fonts/conf.d && \
-    echo '<?xml version="1.0"?>\n\
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">\n\
-<fontconfig>\n\
-  <match target="font">\n\
-    <edit name="rgba" mode="assign">\n\
-      <const>rgb</const>\n\
-    </edit>\n\
-  </match>\n\
-</fontconfig>' > /etc/fonts/local.conf
+    cat > /etc/fonts/local.conf << 'EOF'
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <match target="font">
+    <edit name="rgba" mode="assign">
+      <const>rgb</const>
+    </edit>
+  </match>
+</fontconfig>
+EOF
 
-# Update font cache so Wine can find the system fonts
+# Update font cache
 RUN fc-cache -f -v
 
-# Copy fonts into Wine prefixes so Qt and other Windows apps can find them
-# Wine applications (especially Qt-based GUIs) need fonts in C:\windows\Fonts
-# Copy instead of symlink to ensure proper ownership and access
-RUN mkdir -p ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32/drive_c/windows/Fonts \
-             ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64/drive_c/windows/Fonts && \
-    cp /usr/share/fonts/truetype/msttcorefonts/* ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32/drive_c/windows/Fonts/ && \
-    cp /usr/share/fonts/truetype/msttcorefonts/* ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64/drive_c/windows/Fonts/ && \
-    chown -R ${QCRBOX_USER}:${QCRBOX_USER} \
-        ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32/drive_c/windows/Fonts \
-        ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64/drive_c/windows/Fonts
+# Install fonts using winetricks
+# winetricks properly installs Microsoft Core Fonts and registers them in Wine registry
+RUN export WINEARCH="win32" && \
+    export WINEPREFIX="${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32" && \
+    gosu ${QCRBOX_USER} bash -c 'winetricks corefonts'
+
+RUN export WINEARCH="win64" && \
+    export WINEPREFIX="${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64" && \
+    gosu ${QCRBOX_USER} bash -c 'winetricks corefonts'
 
 USER ${QCRBOX_USER}
+
+# Set shell environment for Wine's system() calls
+ENV SHELL=/bin/bash
 
 ARG QCRBOX_ROOT_DIR=${QCRBOX_ROOT_DIR}
 ARG QCRBOX_HOME=${QCRBOX_ROOT_DIR}

--- a/services/base_images/base_wine/Dockerfile
+++ b/services/base_images/base_wine/Dockerfile
@@ -22,6 +22,22 @@ RUN dpkg --add-architecture i386 && \
     rm -rf /var/lib/apt/lists && \
     true
 
+# Install cabextract (needed to extract font files) and fontconfig
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends cabextract fontconfig && \
+    rm -rf /var/lib/apt/lists
+
+# Manually install Microsoft Core Fonts (ARM-compatible approach)
+# Download and extract the core fonts that Windows applications expect
+RUN mkdir -p /usr/share/fonts/truetype/msttcorefonts && \
+    cd /tmp && \
+    for font in andale32.exe arial32.exe arialb32.exe comic32.exe courie32.exe georgi32.exe impact32.exe times32.exe trebuc32.exe verdan32.exe webdin32.exe; do \
+        wget -q https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/$font && \
+        cabextract -q -d /usr/share/fonts/truetype/msttcorefonts $font && \
+        rm $font; \
+    done && \
+    chmod 644 /usr/share/fonts/truetype/msttcorefonts/*
+
 # Install Mono (https://wiki.winehq.org/Mono)
 RUN mkdir -p /opt/wine-${WINE_BRANCH}/share/wine/mono && \
     wget -O - https://dl.winehq.org/wine/wine-mono/${MONO_VERSION}/wine-mono-${MONO_VERSION}-x86.tar.xz | tar -Jxv -C /opt/wine-${WINE_BRANCH}/share/wine/mono
@@ -58,21 +74,41 @@ RUN mkdir -p \
         ${WINEPREFIX_WIN64} #&& \
     #chmod 777 ${APP_HOME}
 
-
-# Install fonts and enable font smoothing
+# Initialize Wine prefixes without downloading fonts (using native Liberation fonts instead)
+# Using wineboot --init to create Wine prefix structure without executing Windows installers
+# This allows the image to build on ARM via QEMU without hanging
 RUN export WINEARCH="win32" && \
     export WINEPREFIX="${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32" && \
-    gosu ${QCRBOX_USER} bash -c 'winetricks corefonts && winetricks fontsmooth=rgb'
+    gosu ${QCRBOX_USER} bash -c 'DISPLAY= WINEDLLOVERRIDES="mscoree,mshtml=" wineboot --init'
 RUN export WINEARCH="win64" && \
     export WINEPREFIX="${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64" && \
-    gosu ${QCRBOX_USER} bash -c 'winetricks corefonts && winetricks fontsmooth=rgb'
+    gosu ${QCRBOX_USER} bash -c 'DISPLAY= WINEDLLOVERRIDES="mscoree,mshtml=" wineboot --init'
 
-# Create device Y: pointing to the shared files directory
-ARG QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH
-RUN mkdir -p "${WINEPREFIX_WIN32}/dosdevices/" && \
-    ln -f -s "${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}" "${WINEPREFIX_WIN32}/dosdevices/y:"
-RUN mkdir -p "${WINEPREFIX_WIN64}/dosdevices/" && \
-    ln -f -s "${QCRBOX_SHARED_FILES_DIR_CONTAINER_PATH}" "${WINEPREFIX_WIN64}/dosdevices/y:"
+# Configure fontconfig to use RGB subpixel rendering (fixes missing vertical strokes)
+RUN mkdir -p /etc/fonts/conf.d && \
+    echo '<?xml version="1.0"?>\n\
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">\n\
+<fontconfig>\n\
+  <match target="font">\n\
+    <edit name="rgba" mode="assign">\n\
+      <const>rgb</const>\n\
+    </edit>\n\
+  </match>\n\
+</fontconfig>' > /etc/fonts/local.conf
+
+# Update font cache so Wine can find the system fonts
+RUN fc-cache -f -v
+
+# Copy fonts into Wine prefixes so Qt and other Windows apps can find them
+# Wine applications (especially Qt-based GUIs) need fonts in C:\windows\Fonts
+# Copy instead of symlink to ensure proper ownership and access
+RUN mkdir -p ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32/drive_c/windows/Fonts \
+             ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64/drive_c/windows/Fonts && \
+    cp /usr/share/fonts/truetype/msttcorefonts/* ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32/drive_c/windows/Fonts/ && \
+    cp /usr/share/fonts/truetype/msttcorefonts/* ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64/drive_c/windows/Fonts/ && \
+    chown -R ${QCRBOX_USER}:${QCRBOX_USER} \
+        ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win32/drive_c/windows/Fonts \
+        ${QCRBOX_WINE_INSTALLATIONS_DIR}/wine_win64/drive_c/windows/Fonts
 
 USER ${QCRBOX_USER}
 


### PR DESCRIPTION
## This PR addresses the following issue(s)

- Fixes #705 
- Might solve #704 

## Summary of the changes

- Remove installation of fonts via winetricks corefonts which might cause ARM builds to hang 
- Manual font installation: Download Microsoft Core Fonts from SourceForge and extract using cabextract
- RGB subpixel rendering: Configure Wine and fontconfig to use RGB subpixel font smoothing, fixing missing vertical strokes in text characters
- VNC display configuration: Added explicit DPI (96) and color depth (24-bit) settings to TigerVNC for consistent rendering
- Removed obsolete Y: drive mapping: Cleaned up unused legacy feature that mapped shared files directory


## How was it tested?
Manual execution

## Checklist

Please check any boxes that apply to the changes in this PR
(and [cross out](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text) or delete the others).

- [x] There is a GitHub issue describing the problem this PR is solving (please [create](https://github.com/QCrBox/QCrBox/issues/new) one if needed)
- ~~- [ ] I added a changelog entry in `docs/CHANGELOG.md`~~
- ~~- [ ] I added automated tests for my changes~~
- ~~- [ ] I updated any relevant documentation~~
- ~~- [ ] I created separate GitHub issues for any follow-up work needed~~

- ~~- [ ] Example of a crossed-out item that does not apply to this PR~~
